### PR TITLE
Fix icon URL in youtube.leanback.v4.yml

### DIFF
--- a/packages/youtube.leanback.v4.yml
+++ b/packages/youtube.leanback.v4.yml
@@ -1,5 +1,5 @@
 title: YouTube AdFree
-iconUri: https://raw.githubusercontent.com/Ruthenic/youtube-webos/main/largeIcon.png
+iconUri: https://raw.githubusercontent.com/Ruthenic/youtube-webos/main/assets/largeIcon.png
 manifestUrl: https://github.com/Ruthenic/youtube-webos/releases/latest/download/youtube.leanback.v4.manifest.json
 category: entertainment
 description: |


### PR DESCRIPTION
@Informatic's changes moved the icons, which I didn't account for before making the new release of adfree Youtube.