### PR TITLE
Update org.webosbrew.piccap.yml

### DIFF
--- a/packages/org.webosbrew.piccap.yml
+++ b/packages/org.webosbrew.piccap.yml
@@ -1,6 +1,6 @@
 title: PicCap - Hyperion Sender App
 iconUri: https://raw.githubusercontent.com/TBSniller/piccap/main/piccap/logo_big.png
-manifestUrl: https://github.com/TBSniller/piccap/releases/download/release/org.webosbrew.piccap.manifest.json
+manifestUrl: https://github.com/TBSniller/piccap/releases/latest/download/org.webosbrew.piccap.manifest.json
 category: tools
 description: |
  **In early stage development**  


### PR DESCRIPTION
* Use `latest` instead of distinct tag for fetching manifest from GH releases