### PR TITLE
repogen/detail: add source URL link and icon

### DIFF
--- a/content/styles/app.css
+++ b/content/styles/app.css
@@ -1,3 +1,9 @@
 section#content img {
     max-width: 100%;
 }
+
+section#content img.app-icon {
+    max-width: 80px;
+    margin-top: -20px;
+    float: right;
+}

--- a/repogen/templates/apps/detail.md
+++ b/repogen/templates/apps/detail.md
@@ -3,8 +3,11 @@ Status: hidden
 Save_As: apps/{{id}}.html
 
 <link rel="stylesheet" href="/theme/css/app.css" />
+<img src="{{iconUri}}" class="app-icon" alt="{{title}} Icon" />
 
 Version: {{manifest.version}}
+
+{{#manifest.sourceUrl}}Source: [{{manifest.sourceUrl}}]({{manifest.sourceUrl}}){{/manifest.sourceUrl}}
 
 {{#lastmodified}}Last Updated: {{lastmodified}}{{/lastmodified}}
 


### PR DESCRIPTION
Icon has small negative `margin-top` - it would be best to put the `img` itself right before the title `h1`, but this would require theme modifications...