### PR TITLE
Fix icons

### DIFF
--- a/repogen/apidata.py
+++ b/repogen/apidata.py
@@ -46,7 +46,7 @@ def generate(packages: List[PackageInfo], outdir: Path):
             package['fullDescriptionUrl'] = f'apps/{p_info["id"]}/full_description.html'
         if os.environ.get('CI'):
             package['iconUri'] = obtain_icon(package['id'], p_info["iconUri"], site_url)
-            package['manifest']['iconUrl'] = package['iconUri']
+            package['manifest']['iconUri'] = package['iconUri']
         return package
 
     packages_length = len(packages)

--- a/repogen/plugin.py
+++ b/repogen/plugin.py
@@ -27,7 +27,7 @@ class PackageInfoReader(BaseReader):
     def read(self, filename: str):
         info = pkg_info.from_package_info_file(Path(filename), offline='CI' not in os.environ)
         info['iconUri'] = obtain_icon(info['id'], info['iconUri'], self.settings['SITEURL'])
-        info['manifest']['iconUrl'] = info['iconUri']
+        info['manifest']['iconUri'] = info['iconUri']
         metadata = {
             'title': info['title'],
             'override_save_as': f'apps/{info["id"]}.html',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pelican~=4.9.1
+pelican~=4.8.0
 pelican-webassets~=2.0.0
 markdown~=3.6
 pyyaml~=6.0


### PR DESCRIPTION
It seems like the newer version of Pelican (4.9.1, although I haven't tested 4.9.0) refuses to copy the `apps/icons` directory, so roll it back to 4.8.0 for now.

It may be commit pelican/pelican@dbe0b1125f573721dd25211bc19523baf1082425, although that's just a wild guess.