### PR TITLE
Automatic Dev Token Refresh App

### DIFF
--- a/packages/com.pirate.refresh.yml
+++ b/packages/com.pirate.refresh.yml
@@ -1,6 +1,6 @@
 title: Auto Dev Token Refresh
 iconUri: https://raw.githubusercontent.com/LucifersCircle/WebOS-Token-Refresh-App/df2ddd0d429e86b024777f9be762e242e8eb1106/src/app/icon.png
-manifestUrl: https://raw.githubusercontent.com/LucifersCircle/WebOS-Token-Refresh-App/refs/heads/main/manifest.json
+manifestUrl: https://github.com/LucifersCircle/WebOS-Token-Refresh-App/releases/latest/download/manifest.json
 category: system
 pool: main
 description: |

--- a/packages/com.pirate.refresh.yml
+++ b/packages/com.pirate.refresh.yml
@@ -1,6 +1,6 @@
 title: Auto Dev Token Refresh
 iconUri: https://github.com/LucifersCircle/WebOS-Token-Refresh-App/blob/main/src/app/icon.png?raw=true
-manifestUrl: https://raw.githubusercontent.com/LucifersCircle/WebOS-Token-Refresh-App/refs/heads/main/src/app/appinfo.json
+manifestUrl: https://raw.githubusercontent.com/LucifersCircle/WebOS-Token-Refresh-App/refs/heads/main/manifest.json
 category: system
 pool: main
 description: |

--- a/packages/com.pirate.refresh.yml
+++ b/packages/com.pirate.refresh.yml
@@ -1,5 +1,5 @@
 title: Auto Dev Token Refresh
-iconUri: https://github.com/LucifersCircle/WebOS-Token-Refresh-App/blob/main/src/app/icon.png?raw=true
+iconUri: https://raw.githubusercontent.com/LucifersCircle/WebOS-Token-Refresh-App/df2ddd0d429e86b024777f9be762e242e8eb1106/src/app/icon.png
 manifestUrl: https://raw.githubusercontent.com/LucifersCircle/WebOS-Token-Refresh-App/refs/heads/main/manifest.json
 category: system
 pool: main

--- a/packages/com.pirate.refresh.yml
+++ b/packages/com.pirate.refresh.yml
@@ -1,0 +1,20 @@
+title: Auto Dev Token Refresh
+iconUri: https://github.com/LucifersCircle/WebOS-Token-Refresh-App/blob/main/src/app/icon.png?raw=true
+manifestUrl: https://raw.githubusercontent.com/LucifersCircle/WebOS-Token-Refresh-App/refs/heads/main/src/app/appinfo.json
+category: system
+pool: main
+description: |
+
+  # WebOS Token Refresher
+
+  A secure web-based tool for refreshing LG WebOS developer mode session tokens. This project ensures your token is stored securely and refreshes it periodically with the LG Developer API. Keys are refreshed using (https://lg.pirate.vodka)
+
+  ![Screenshot](https://github.com/LucifersCircle/WebOS-Token-Refresh-App/blob/main/img/Screenshot%202024-12-12%20142711.png?raw=true)
+  
+  Your TV does NOT need to be rooted to use this.
+
+  Source code on [GitHub](https://github.com/LucifersCircle/WebOS-Token-Refresh-App).
+  Source code for lg.pirate.vodka also available on [GitHub](https://github.com/LucifersCircle/webOS-Token-Refresh)
+
+funding:
+  github: [ LucifersCircle ]


### PR DESCRIPTION
added automatic dev token refresh app. This queries against a server located at lg.pirate.vodka, which has an open source infrastructure.

- side note, I'm pretty sure I did my manifest wrong, if so please let me know and I'll change it in the app to better reflect other linked manifests, although I'm not totally sure where they got all the entries inside their manifests. 

https://github.com/LucifersCircle/WebOS-Token-Refresh-App