### PR TITLE
OpenTTD: First submission

### DIFF
--- a/packages/com.leondrolio.x.openttd.yml
+++ b/packages/com.leondrolio.x.openttd.yml
@@ -1,0 +1,20 @@
+title: OpenTTD
+iconUri: https://raw.githubusercontent.com/7coil/webos-openttd/webos/os/webos/public/icon.png
+manifestUrl: https://github.com/7coil/webos-openttd/releases/latest/download/manifest.json
+category: game
+pool: main
+description: |
+  # OpenTTD
+
+  OpenTTD is an open source simulation game based on Transport Tycoon Deluxe.
+
+  This version is not built, maintained, distributed, etc. by OpenTTD Team.  
+
+  ## Usage
+
+  Use a mouse and keyboard connected to the television set for the best experience.
+
+  ## Licencing
+
+  OpenTTD, OpenGFX and OpenMSX is released under the GNU General Public Licence (GPL) version 2.  
+  OpenSFX is released under the Creative Commons Attribution-ShareAlike 3.0 Unported license.


### PR DESCRIPTION
not guaranteed to run on an LG C9 (it crashes)
is guaranteed to run on an LG C2 (it doesnt crash as much)

![1ae72a_1dbf9dfbef3f436da345367bf0be4171~mv2](https://github.com/user-attachments/assets/d0d5cd64-f270-4972-82cd-220e66444e95)
