### PR TITLE
App submission - Bluetooth Disabler

### DIFF
--- a/packages/pl.krzywro.webos-bluetooth-disabler.yml
+++ b/packages/pl.krzywro.webos-bluetooth-disabler.yml
@@ -1,0 +1,14 @@
+title: Bluetooth Disabler
+iconUri: https://raw.githubusercontent.com/krzywro/webos-bluetooth-disabler/main/assets/icon160.png
+manifestUrl: https://github.com/krzywro/webos-bluetooth-disabler/releases/latest/download/pl.krzywro.webos-bluetooth-disabler.manifest.json
+category: utility
+pool: main
+description: |
+  # Bluetooth Disabler
+
+  Root required
+
+  # Features
+
+  * Start/stop Bluetooth service on demand
+  * Automatically disable Bluetooth after boot


### PR DESCRIPTION
Simple application that allows managing of system's Bluetooth service (enable/disable/disable on boot). Root required to operate.

Tested on OLED48C21LA with webOS24 / 9.2.1-2605