### PR TITLE
Add App Update Blocker

### DIFF
--- a/packages/org.webosbrew.appupdateblocker.yml
+++ b/packages/org.webosbrew.appupdateblocker.yml
@@ -1,0 +1,17 @@
+title: LG App Update Blocker
+iconUri: https://raw.githubusercontent.com/dr0dr1dr2dr3/lgappupdateblocker/master/assets/icon.png
+manifestUrl: https://github.com/dr0dr1dr2dr3/lgappupdateblocker/releases/download/1.0.0/org.webosbrew.appupdateblocker.manifest.json
+category: utility
+pool: main
+description: |
+ # LG App Update Blocker
+ 
+ Lets you bypass the requirement to update the app before you can launch it.
+ 
+ Additionally, lets you null route the update servers in the hosts file.
+ 
+ The [homebrew channel](https://github.com/webosbrew/webos-homebrew-channel/) with root access is required.
+ 
+ ## Acknowledgements
+ 
+ [Simon34545](https://github.com/Simon34545/lginputhook) - I ripped a lot of code from him


### PR DESCRIPTION
This lets you remove the updates file that forces you to connect to LG's servers and update an app before you're allowed to use it again. It also has a feature to install an init.d script to append the LG update servers to the hosts file and null route them.

I also threw in a ssh key clearer for good measure, because it would suck to lose root access.

### Relevant issues

Block Content Store - webosbrew/webos-homebrew-channel/issues/85
Add "Clear SSH keys" button - webosbrew/webos-homebrew-channel/issues/218