### PR TITLE
repogen: bump up items per page in API

### DIFF
--- a/repogen/common.py
+++ b/repogen/common.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 import requests
 
-ITEMS_PER_PAGE: int = 30
+ITEMS_PER_PAGE: int = 50
 
 F = TypeVar("F", bound=Callable)
 


### PR DESCRIPTION
This is a hacky workaround for https://github.com/webosbrew/youtube-webos/issues/410