### PR TITLE
Add Moonfin client configuration for webOS

### DIFF
--- a/packages/org.moonfin.webos.yml
+++ b/packages/org.moonfin.webos.yml
@@ -1,0 +1,7 @@
+title: Moonfin
+iconUri: https://raw.githubusercontent.com/Moonfin-Client/WebOS/master/resources/icon-130.png
+manifestUrl: https://github.com/Moonfin-Client/WebOS/releases/latest/download/org.moonfin.webos.manifest.json
+category: multimedia
+pool: main
+description: |
+  Moonfin is an enhanced Jellyfin client for LG Smart TVs supporting webOS 4+


### PR DESCRIPTION
Hi! I am submitting my client for jellyfin, looking forward to feedback and/or approval!. For testing you can use a regular jellyfin server or https://demo.jellyfin.org as the URL