### PR TITLE
Add Immich TV

### DIFF
--- a/packages/com.seeky91.immichtv.yml
+++ b/packages/com.seeky91.immichtv.yml
@@ -1,0 +1,36 @@
+title: Immich TV
+iconUri: https://raw.githubusercontent.com/Seeky91/immich-tv-webos/main/assets/icon-store.png
+detailIconUri: https://raw.githubusercontent.com/Seeky91/immich-tv-webos/main/assets/icon-source.png
+manifestUrl: https://github.com/Seeky91/immich-tv-webos/releases/latest/download/manifest.json
+category: multimedia
+pool: main
+description: |
+  A read-only client for [Immich](https://immich.app/) — the self-hosted photo
+  and video management platform — designed and optimized for LG webOS Smart TVs.
+
+  Browse your entire library on the big screen with native D-pad navigation, a
+  justified-grid timeline, and full-screen media playback.
+
+  ## Features
+
+  - **Timeline** — Infinite-scrolling photo & video timeline grouped by date
+  - **Albums** — Browse and explore your Immich albums
+  - **Search** — Smart text search powered by Immich's ML backend, plus face/person search via the People ribbon
+  - **Justified grid** — Layout that respects original aspect ratios while keeping rows aligned
+  - **Virtualized rendering** — Smooth performance on libraries with thousands of assets
+  - **D-pad first** — Native integration with webOS Spotlight; designed for the remote, not a mouse
+  - **4K-aware** — UI calibrated for FHD and 4K TVs
+  - **Two auth modes** — Email/password login OR API key
+
+  ## Setup
+
+  1. Launch the app and enter your Immich server URL
+  2. Sign in with your email/password, or paste an API key
+  3. Done — your timeline loads
+
+  ## Disclaimer
+
+  Unofficial third-party client. Not affiliated with the official Immich
+  development team. Provided "as is" for personal use on LG Smart TVs.
+funding:
+  custom: ["bitcoin:bc1qvxczfmurlglff6zmkgysnxy2yglvwspalcd373"]


### PR DESCRIPTION
## Adding Immich TV

A read-only client for [Immich](https://immich.app/) — the self-hosted photo and video management platform — designed and optimized for LG webOS Smart TVs.

- **Source:** https://github.com/Seeky91/immich-tv-webos
- **License:** MIT
- **Pool:** main (open-source)
- **Category:** multimedia
- **Built with:** Enact + Sandstone (LG's official TV component library)

## Compliance with the rules

- **No piracy** — the app is a client for a **self-hosted** personal photo server (Immich). It cannot access any third-party / DRM-protected content. Users can only see their own data, on their own server.
- **Safe for the TV** — the app is purely a viewer (read-only HTTP requests, no firmware-level operations, no writes back to the server, no system changes). Standard webOS web app, sandboxed.
- **Original work** — written from scratch in TypeScript with the official Enact framework. MIT licensed. Not a port of any existing app.

## Highlights

- Infinite-scrolling timeline grouped by date, with a justified-grid layout that respects original aspect ratios
- Albums browser, smart text search, face/person search via the People ribbon
- Native D-pad navigation through webOS Spotlight (designed for the remote, not a mouse)
- Two auth modes: email/password OR API key
- 4K-aware UI calibrated for FHD and 4K TVs

Tested on webOS 6.x. Should work on webOS 4.x+ given the Enact Sandstone version used.