### PR TITLE
Add com.siaivo.tv package

### DIFF
--- a/packages/com.lampaua.tv.yml
+++ b/packages/com.lampaua.tv.yml
@@ -1,0 +1,15 @@
+﻿title: LampaUa
+iconUri: https://raw.githubusercontent.com/Hlushok/lampaua-webos/main/icon-512.png
+manifestUrl: https://raw.githubusercontent.com/Hlushok/lampaua-webos/main/com.lampaua.tv.manifest.json
+category: media
+pool: main
+description: |
+  LampaUa for LG webOS.
+
+  Features
+  --------
+  * webOS package distribution via GitHub Releases
+  * Manifest-based updates
+  * TV-friendly icon and metadata
+funding:
+  github: [ Hlushok ]


### PR DESCRIPTION
Adds Siaivo (com.siaivo.tv) package entry with public manifest hosted on GitHub.\n\n- Manifest: https://raw.githubusercontent.com/Hlushok/lampaua-webos/main/com.siaivo.tv.manifest.json\n- Icon: https://raw.githubusercontent.com/Hlushok/lampaua-webos/main/icon-512.png\n- Release asset: https://github.com/Hlushok/lampaua-webos/releases/tag/v1.0.2\n\nThis package is submitted as a clean webOS wrapper.