### PR TITLE
Add decoder-bench app

### DIFF
--- a/packages/io.github.beatcracker.decoderbench.yml
+++ b/packages/io.github.beatcracker.decoderbench.yml
@@ -3,6 +3,8 @@ iconUri: https://raw.githubusercontent.com/beatcracker/decoder-bench/master/asse
 manifestUrl: https://github.com/beatcracker/decoder-bench/releases/latest/download/io.github.beatcracker.decoderbench.manifest.json
 category: multimedia
 pool: main
+requirements:
+  webosRelease: '>=5.0'
 description: |
   Native decoder benchmark for rooted LG webOS TVs.
 

--- a/packages/io.github.beatcracker.decoderbench.yml
+++ b/packages/io.github.beatcracker.decoderbench.yml
@@ -1,0 +1,13 @@
+title: Decoder bench
+iconUri: https://raw.githubusercontent.com/beatcracker/decoder-bench/master/assets/webos/icon_large.png
+manifestUrl: https://github.com/beatcracker/decoder-bench/releases/latest/download/io.github.beatcracker.decoderbench.manifest.json
+category: multimedia
+pool: main
+description: |
+  Native decoder benchmark for rooted LG webOS TVs.
+
+  Runs bundled or USB benchmark suites against the local video decoder pipeline and writes CSV/log results for codec, resolution, frame-rate, and bitrate limits. Built while chasing a Moonlight/Sunshine bitrate limit on an LG C1.
+
+  Requires root for USB access.
+
+  Download the full USB test suite from the [GitHub releases](https://github.com/beatcracker/decoder-bench/releases).


### PR DESCRIPTION
## New app: Decoder bench

Native decoder benchmark for rooted LG webOS TVs.

- **App ID:** `io.github.beatcracker.decoderbench`
- **Source:** https://github.com/beatcracker/decoder-bench
- **Category:** multimedia
- **Pool:** main (open source, GPL-3.0)
- **Version:** 1.0.0

### What it does

Decoder bench stress-tests the TV's local video decoder pipeline directly, using bundled fixtures or an extended USB benchmark suite. It writes CSV results and logs for codec, resolution, frame-rate, and bitrate limits.

I built it while chasing a Moonlight/Sunshine bitrate limit on an LG C1 and wanted to check whether the TV decoder was actually the bottleneck.

### Notes

Root is required for USB suite access. The full USB test suite is available from the GitHub release assets.

### Checklist

- [x] No piracy
- [x] Open source (GPL-3.0)
- [x] `rootRequired: true`
- [x] manifest.json uploaded to GitHub release
- [x] IPK SHA256 verified