### PR TITLE
Add Immich webOS TV app

### DIFF
--- a/packages/com.immich.webos.yml
+++ b/packages/com.immich.webos.yml
@@ -8,6 +8,9 @@ manifestUrl: https://github.com/aneeshtigga/immich-webos/releases/latest/downloa
 category: multimedia
 # If this is an open source application, use main, otherwise non-free
 pool: main
+# Minimum webOS release. The bundle uses ES2017, supported on webOS 5.0+ (Chromium 68+).
+requirements:
+  webosRelease: '>=5.0'
 # Long description for your application, in Markdown format
 description: |
   Native webOS TV client for Immich, the self-hosted photo and video backup

--- a/packages/com.immich.webos.yml
+++ b/packages/com.immich.webos.yml
@@ -1,0 +1,27 @@
+# Display name of your application
+title: Immich
+# Publicly accesible HTTP/HTTPS URL, or data uri to icon image.
+iconUri: https://raw.githubusercontent.com/aneeshtigga/immich-webos/main/src/assets/logo-sm.png
+# Publicly accessible manifest file of your application
+manifestUrl: https://github.com/aneeshtigga/immich-webos/releases/latest/download/com.immich.webos.manifest.json
+# Category for your application
+category: multimedia
+# If this is an open source application, use main, otherwise non-free
+pool: main
+# Long description for your application, in Markdown format
+description: |
+  Native webOS TV client for Immich, the self-hosted photo and video backup
+  solution. Browse your library, albums, and search your Immich server directly
+  from your LG TV.
+
+  - Timeline and album browsing optimised for the 10-foot / remote experience
+  - Full-text and metadata search
+  - Email + password or API key sign-in, via on-screen form or QR code for mobile input
+
+  Requires your own Immich server. Not affiliated with the Immich project.
+
+  ## Screenshots
+  ![Timeline grid](https://raw.githubusercontent.com/aneeshtigga/immich-webos/main/screenshots/grid.png)
+# Sponsor information, like .github/FUNDING.yml
+funding:
+  github: [ aneeshtigga ]


### PR DESCRIPTION
Adds `packages/com.immich.webos.yml` for **Immich** — a native webOS TV client for the self-hosted [Immich](https://immich.app) photo/video server.

- **Pool:** main (open source, MIT)
- **Category:** multimedia
- **Source:** https://github.com/aneeshtigga/immich-webos
- **Manifest:** https://github.com/aneeshtigga/immich-webos/releases/latest/download/com.immich.webos.manifest.json

Manifest + `.ipk` are published via GitHub Releases; `ipkHash.sha256` verified against the served `.ipk`. Requires a user-provided Immich server; not affiliated with the Immich project.