### PR TITLE
Add webOS Terminal

### DIFF
--- a/packages/com.github.gprot42.webosterminal.yml
+++ b/packages/com.github.gprot42.webosterminal.yml
@@ -20,6 +20,7 @@ description: |
   - Multiple tabs, each with its own shell session
   - Remote-friendly key bar (Ctrl, Esc, Tab, arrow keys)
   - Native PTY support via `ptybridge` for job control and TUI apps (`vim`, `htop`, `less`, `tmux`)
+  - Shell automation API for remote `luna-send` control (SSH scripting, session listing, command execution)
 
   ## Requirements
 

--- a/packages/com.github.gprot42.webosterminal.yml
+++ b/packages/com.github.gprot42.webosterminal.yml
@@ -19,14 +19,15 @@ description: |
   - Interactive shell on your TV using the remote and on-screen keyboard
   - Multiple tabs, each with its own shell session
   - Remote-friendly key bar (Ctrl, Esc, Tab, arrow keys)
-  - Native PTY support via `ptybridge` for job control and TUI apps (`vim`, `htop`, `less`, `tmux`)
+  - Native PTY via `ptybridge` with **raw keystroke passthrough** when elevated — shell history, tab completion, job control, and full-screen apps (`vim`, `htop`, `less`, `tmux`)
+  - Piped-shell fallback with client-side line history when a PTY is unavailable
   - Shell automation API for remote `luna-send` control (SSH scripting, session listing, command execution)
   - Bundled monospace font selection (JetBrains Mono, IBM Plex Mono, Cascadia Mono, DejaVu Sans Mono, Fira Mono) with live preview
 
   ## Requirements
 
   - Rooted LG webOS TV with [Homebrew Channel](https://github.com/webosbrew/webos-homebrew-channel/)
-  - webOS 4.x or newer (v0.0.9+)
+  - webOS 4.x or newer (v0.0.11+)
 
   For full PTY/TUI support, elevate the shell service to root — see the [install guide](https://github.com/gprot42/webos-terminal/blob/main/README.install.md#running-as-root).
 

--- a/packages/com.github.gprot42.webosterminal.yml
+++ b/packages/com.github.gprot42.webosterminal.yml
@@ -25,7 +25,7 @@ description: |
   ## Requirements
 
   - Rooted LG webOS TV with [Homebrew Channel](https://github.com/webosbrew/webos-homebrew-channel/)
-  - webOS 4.x or newer recommended
+  - webOS 4.x or newer (v0.0.8+)
 
   For full PTY/TUI support, elevate the shell service to root — see the [install guide](https://github.com/gprot42/webos-terminal/blob/main/README.install.md#running-as-root).
 

--- a/packages/com.github.gprot42.webosterminal.yml
+++ b/packages/com.github.gprot42.webosterminal.yml
@@ -1,6 +1,6 @@
 title: webOS Terminal
 iconUri: https://raw.githubusercontent.com/gprot42/webos-terminal/main/webos-meta/icon-large.png
-manifestUrl: https://github.com/gprot42/webos-terminal/releases/latest/download/org.webosbrew.terminal.manifest.json
+manifestUrl: https://github.com/gprot42/webos-terminal/releases/latest/download/com.github.gprot42.webosterminal.manifest.json
 category: utility
 pool: main
 requirements:

--- a/packages/com.github.gprot42.webosterminal.yml
+++ b/packages/com.github.gprot42.webosterminal.yml
@@ -21,11 +21,12 @@ description: |
   - Remote-friendly key bar (Ctrl, Esc, Tab, arrow keys)
   - Native PTY support via `ptybridge` for job control and TUI apps (`vim`, `htop`, `less`, `tmux`)
   - Shell automation API for remote `luna-send` control (SSH scripting, session listing, command execution)
+  - Bundled monospace font selection (JetBrains Mono, IBM Plex Mono, Cascadia Mono, DejaVu Sans Mono, Fira Mono) with live preview
 
   ## Requirements
 
   - Rooted LG webOS TV with [Homebrew Channel](https://github.com/webosbrew/webos-homebrew-channel/)
-  - webOS 4.x or newer (v0.0.8+)
+  - webOS 4.x or newer (v0.0.9+)
 
   For full PTY/TUI support, elevate the shell service to root — see the [install guide](https://github.com/gprot42/webos-terminal/blob/main/README.install.md#running-as-root).
 

--- a/packages/com.github.gprot42.webosterminal.yml
+++ b/packages/com.github.gprot42.webosterminal.yml
@@ -1,5 +1,5 @@
 title: webOS Terminal
-iconUri: https://raw.githubusercontent.com/gprot42/webos-terminal/main/webos-meta/icon-large.png
+iconUri: https://cdn.jsdelivr.net/gh/gprot42/webos-terminal@main/webos-meta/icon-large.png
 manifestUrl: https://github.com/gprot42/webos-terminal/releases/latest/download/com.github.gprot42.webosterminal.manifest.json
 category: utility
 pool: main
@@ -10,7 +10,7 @@ description: |
 
   A native terminal app for LG webOS TVs. Open a shell right on your TV — no laptop required.
 
-  ![Screenshot](https://raw.githubusercontent.com/gprot42/webos-terminal/main/docs/images/screengrab1.jpg)
+  ![Screenshot](https://cdn.jsdelivr.net/gh/gprot42/webos-terminal@main/docs/images/screengrab1.jpg)
 
   **Root required.** This app only works on a **rooted** LG webOS TV with **Homebrew Channel** installed.
 

--- a/packages/org.webosbrew.terminal.yml
+++ b/packages/org.webosbrew.terminal.yml
@@ -1,0 +1,33 @@
+title: webOS Terminal
+iconUri: https://raw.githubusercontent.com/gprot42/webos-terminal/main/webos-meta/icon-large.png
+manifestUrl: https://github.com/gprot42/webos-terminal/releases/latest/download/org.webosbrew.terminal.manifest.json
+category: utility
+pool: main
+requirements:
+  webosRelease: '>=4.0'
+description: |
+  # webOS Terminal
+
+  A native terminal app for LG webOS TVs. Open a shell right on your TV — no laptop required.
+
+  ![Screenshot](https://raw.githubusercontent.com/gprot42/webos-terminal/main/docs/images/screengrab1.jpg)
+
+  **Root required.** This app only works on a **rooted** LG webOS TV with **Homebrew Channel** installed.
+
+  ## Features
+
+  - Interactive shell on your TV using the remote and on-screen keyboard
+  - Multiple tabs, each with its own shell session
+  - Remote-friendly key bar (Ctrl, Esc, Tab, arrow keys)
+  - Native PTY support via `ptybridge` for job control and TUI apps (`vim`, `htop`, `less`, `tmux`)
+
+  ## Requirements
+
+  - Rooted LG webOS TV with [Homebrew Channel](https://github.com/webosbrew/webos-homebrew-channel/)
+  - webOS 4.x or newer recommended
+
+  For full PTY/TUI support, elevate the shell service to root — see the [install guide](https://github.com/gprot42/webos-terminal/blob/main/README.install.md#running-as-root).
+
+  ## Source
+
+  [github.com/gprot42/webos-terminal](https://github.com/gprot42/webos-terminal) (MIT)


### PR DESCRIPTION
## Summary

Adds **webOS Terminal** (`com.github.gprot42.webosterminal`) to the Homebrew Channel app repository.

- **Source:** https://github.com/gprot42/webos-terminal
- **License:** MIT
- **Category:** utility
- **Root required:** yes
- **Latest release:** [v0.0.11](https://github.com/gprot42/webos-terminal/releases/tag/v0.0.11)

Native terminal emulator for rooted LG webOS TVs. Provides interactive shell access on the TV itself (no laptop/SSH required), with multi-tab support, remote-friendly key bar, native PTY support via `ptybridge` with raw keystroke passthrough (shell history, tab completion, job control, full-screen apps), shell automation API for remote `luna-send` scripting, and bundled monospace font selection with live preview.

## Release assets

- Manifest: https://github.com/gprot42/webos-terminal/releases/latest/download/com.github.gprot42.webosterminal.manifest.json
- IPK (v0.0.11): https://github.com/gprot42/webos-terminal/releases/download/v0.0.11/com.github.gprot42.webosterminal_0.0.11_all.ipk

`manifestUrl` points at `releases/latest`, so Homebrew Channel always installs the current release.

## Test plan

- [x] Manifest URL resolves and contains valid `ipkHash` / `ipkUrl` (v0.0.11)
- [x] IPK installs via Homebrew Channel / sideload on a rooted TV
- [x] App launches and opens an interactive shell session
- [x] Live tested on rooted TV (v0.0.11 installed)
- [x] With service elevated as root: PTY raw input (history, tab complete, Ctrl sequences)