### PR TITLE
Update webOS Terminal: webOS 2 support + smaller IPK (v0.0.12)

### DIFF
--- a/packages/com.github.gprot42.webosterminal.yml
+++ b/packages/com.github.gprot42.webosterminal.yml
@@ -4,7 +4,7 @@ manifestUrl: https://github.com/gprot42/webos-terminal/releases/latest/download/
 category: utility
 pool: main
 requirements:
-  webosRelease: '>=4.0'
+  webosRelease: '>=1.0'
 description: |
   # webOS Terminal
 
@@ -17,17 +17,19 @@ description: |
   ## Features
 
   - Interactive shell on your TV using the remote and on-screen keyboard
-  - Multiple tabs, each with its own shell session
+  - Multiple tabs, each with its own shell session (full UI on webOS 3+)
   - Remote-friendly key bar (Ctrl, Esc, Tab, arrow keys)
   - Native PTY via `ptybridge` with **raw keystroke passthrough** when elevated — shell history, tab completion, job control, and full-screen apps (`vim`, `htop`, `less`, `tmux`)
   - Piped-shell fallback with client-side line history when a PTY is unavailable
   - Shell automation API for remote `luna-send` control (SSH scripting, session listing, command execution)
   - Bundled monospace font selection (JetBrains Mono, IBM Plex Mono, Cascadia Mono, DejaVu Sans Mono, Fira Mono) with live preview
+  - **webOS 1–2 support** via dual-boot **cut-down legacy shell** (vanilla ES5) — confirmed on webOS 2
+  - Compact package — IPK is about **~1.7 MB** (pruned locales/fonts)
 
   ## Requirements
 
   - Rooted LG webOS TV with [Homebrew Channel](https://github.com/webosbrew/webos-homebrew-channel/)
-  - webOS 4.x or newer (v0.0.11+)
+  - **webOS 4+** for the full multi-tab React/xterm UI; **webOS 3** experimental; **webOS 1–2** use the cut-down legacy shell (v0.0.12+)
 
   For full PTY/TUI support, elevate the shell service to root — see the [install guide](https://github.com/gprot42/webos-terminal/blob/main/README.install.md#running-as-root).
 


### PR DESCRIPTION
## Summary

Updates the **webOS Terminal** (`com.github.gprot42.webosterminal`) listing for **v0.0.12**:

1. **webOS 1–2 support** — dual-boot cut-down legacy shell (vanilla ES5) when the TV is pre-Chromium WebKit; **confirmed working on webOS 2**
2. **Smaller package** — IPK is now ~**1.7 MB** (pruned iLib locales / fonts; was ~9 MB)

Also lowers `requirements.webosRelease` from `>=4.0` to `>=1.0` so older rooted TVs can discover/install via Homebrew Channel. Description clarifies tiers: full UI on webOS 4+, experimental on 3.x, legacy shell on 1–2.

- **Source:** https://github.com/gprot42/webos-terminal
- **Release:** https://github.com/gprot42/webos-terminal/releases/tag/v0.0.12
- **`manifestUrl`** still points at `releases/latest` (already serves 0.0.12)

## Test plan

- [x] Latest manifest resolves to v0.0.12 with valid `ipkHash` / `ipkSize` (~1.7 MB)
- [x] v0.0.12 IPK published on GitHub Releases
- [x] Legacy shell confirmed on webOS 2 hardware
- [ ] Listing text renders correctly on repo.webosbrew.org after merge
- [ ] Homebrew Channel can install latest on a rooted TV