### PR TITLE
Add Alcyone XRay and sing-box

### DIFF
--- a/packages/com.alcyone.vpn.singbox.yml
+++ b/packages/com.alcyone.vpn.singbox.yml
@@ -1,0 +1,37 @@
+title: Alcyone sing-box
+iconUri: https://ichikanya.github.io/Alcyone/icon.png
+manifestUrl: https://ichikanya.github.io/Alcyone/com.alcyone.vpn.singbox.manifest.json
+category: system
+pool: non-free
+requirements:
+  webosRelease: '>=4.0'
+description: |
+  # Alcyone sing-box
+
+  A low-resource VPN client for rooted LG webOS TVs. This edition uses sing-box
+  with a native system TUN process and is optimized for low-powered TVs, stable
+  resource use, and fast startup. It imports user-provided VLESS, VMess, Trojan,
+  Shadowsocks, SOCKS5, and Hysteria2 profiles and subscriptions.
+
+  **Root is required.** While connected, Alcyone creates a system-wide `tun0`
+  interface and changes the TV routing table. Disconnecting stops the VPN
+  process and removes its tunnel routes. Autostart is optional and can be
+  removed in the app. Uninstalling does not promise to erase profiles stored
+  under `/var/lib/alcyone-singbox`, so users should remove sensitive local data
+  separately if needed.
+
+  Requires webOS 4 or newer because earlier webOS releases do not provide the
+  required TUN kernel module. Installation, VPN connection, network restoration,
+  and autostart after reboot were tested successfully on an LG 55UK6200PLA
+  running webOS release 4.4.3-22.
+
+  Profiles and subscription URLs are stored locally on the TV. Subscription
+  updates contact the provider URL configured by the user. External-IP checks
+  contact public IP-check services. The LAN web importer listens on port 8081,
+  so it should only be enabled on a trusted local network.
+
+  Alcyone does not include VPN accounts, media, piracy services, or DRM-bypass
+  functionality. Users supply and are responsible for their own VPN service.
+
+  Source and installation details:
+  [github.com/ichikanya/Alcyone](https://github.com/ichikanya/Alcyone)

--- a/packages/com.alcyone.vpn.yml
+++ b/packages/com.alcyone.vpn.yml
@@ -3,6 +3,8 @@ iconUri: https://ichikanya.github.io/Alcyone/icon.png
 manifestUrl: https://ichikanya.github.io/Alcyone/com.alcyone.vpn.manifest.json
 category: system
 pool: non-free
+requirements:
+  webosRelease: '>=4.0'
 description: |
   # Alcyone XRay
 
@@ -16,6 +18,11 @@ description: |
   removed in the app. Uninstalling does not promise to erase profiles stored
   under `/var/lib/alcyone`, so users should remove sensitive local data
   separately if needed.
+
+  Requires webOS 4 or newer because earlier webOS releases do not provide the
+  required TUN kernel module. Installation, VPN connection, network restoration,
+  and autostart after reboot were tested successfully on an LG 55UK6200PLA
+  running webOS release 4.4.3-22.
 
   Profiles and subscription URLs are stored locally on the TV. Subscription
   updates contact the provider URL configured by the user. External-IP checks

--- a/packages/com.alcyone.vpn.yml
+++ b/packages/com.alcyone.vpn.yml
@@ -1,0 +1,29 @@
+title: Alcyone XRay
+iconUri: https://ichikanya.github.io/Alcyone/icon.png
+manifestUrl: https://ichikanya.github.io/Alcyone/com.alcyone.vpn.manifest.json
+category: system
+pool: non-free
+description: |
+  # Alcyone XRay
+
+  A VPN client for rooted LG webOS TVs. It imports user-provided VLESS, VMess,
+  Trojan, Shadowsocks, SOCKS5, and Hysteria2 profiles and subscriptions, then
+  routes TV traffic through the selected server using Xray and tun2socks.
+
+  **Root is required.** While connected, Alcyone creates a system-wide `tun0`
+  interface and changes the TV routing table. Disconnecting stops the VPN
+  processes and removes its tunnel routes. Autostart is optional and can be
+  removed in the app. Uninstalling does not promise to erase profiles stored
+  under `/var/lib/alcyone`, so users should remove sensitive local data
+  separately if needed.
+
+  Profiles and subscription URLs are stored locally on the TV. Subscription
+  updates contact the provider URL configured by the user. External-IP checks
+  contact public IP-check services. The LAN web importer listens on port 8080,
+  so it should only be enabled on a trusted local network.
+
+  Alcyone does not include VPN accounts, media, piracy services, or DRM-bypass
+  functionality. Users supply and are responsible for their own VPN service.
+
+  Source and installation details:
+  [github.com/ichikanya/Alcyone](https://github.com/ichikanya/Alcyone)


### PR DESCRIPTION
#### Application description

Adds both independently installable Alcyone VPN editions for rooted LG webOS TVs:

- **Alcyone XRay** (`com.alcyone.vpn`) keeps the established Xray core and is intended for large subscriptions, XHTTP, and complete Xray configurations.
- **Alcyone sing-box** (`com.alcyone.vpn.singbox`) uses a native sing-box TUN process optimized for low-powered TVs, stable resource use, and fast startup.

Both catalog entries document their system-wide TUN routing changes, reversibility, local profile storage, external network requests, root requirement, and the absence of bundled VPN accounts, piracy services, or DRM-bypass functionality.

Both editions require webOS 4 or newer because earlier releases do not provide the required TUN kernel module. Installation, VPN connection, normal-route restoration after disconnect, and autostart after reboot were tested for both editions on an LG 55UK6200PLA running webOS release 4.4.3-22.

The packages are submitted to the non-free pool because the source repository does not declare a license.

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [x] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [ ] Other (please describe below).

#### Validation

- `python -m repogen.lintpkg -f packages/com.alcyone.vpn.yml`
- `python -m repogen.lintpkg -f packages/com.alcyone.vpn.singbox.yml`
- Public manifests, icon, and IPK URLs return successfully.
- Published IPK SHA-256 values match their manifests.