### PR TITLE
Add Punktfunk client (io.dyptan.punktfunk.webos)

### DIFF
--- a/packages/io.dyptan.punktfunk.webos.yml
+++ b/packages/io.dyptan.punktfunk.webos.yml
@@ -4,6 +4,8 @@ manifestUrl: https://github.com/dyptan-io/punktfunk-webos/releases/latest/downlo
 category: game
 pool: main
 description: |
+  ![punktfunk](https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/logo/logo-sidebar.png)
+
   Low-latency desktop & game streaming for LG webOS.
 
   ![Home screen](https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/screenshots/home.jpg)

--- a/packages/io.dyptan.punktfunk.webos.yml
+++ b/packages/io.dyptan.punktfunk.webos.yml
@@ -1,29 +1,25 @@
-title: punktfunk
-iconUri: https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/logo/logo-sidebar.png
+title: Punktfunk
+iconUri: https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/packaging/icon_large.png
 manifestUrl: https://github.com/dyptan-io/punktfunk-webos/releases/latest/download/io.dyptan.punktfunk.webos.manifest.json
 category: game
 pool: main
 description: |
-  Native LG webOS TV client for [punktfunk](https://git.unom.io/unom/punktfunk) — low-latency desktop & game streaming.
+  Low-latency desktop & game streaming for LG webOS.
 
-  Targets webOS 5.x+ (developed and verified on an LG CX, webOS 5.6). Built on the punktfunk project
-  by Enrico Bühler — this is the webOS-specific client with SDL2 UI, NDL DirectMedia hardware video
-  decode, and webOS packaging.
+  ![Home screen](https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/screenshots/home.jpg)
 
-  ## Features
+  * Find hosts on your network automatically, or add one by IP; pair once with a PIN.
+  * Choose resolution (1080p/1440p/4K), frame rate, bitrate, and HDR.
+  * Browse the host's game library with cover art and launch straight into a game.
+  * Smooth hardware-accelerated video with low latency.
+  * Control it with the Magic Remote, a gamepad, keyboard, or mouse.
 
-  * LAN discovery (mDNS) or manual host addition by IP; PIN pairing with persisted trust
-  * Hardware H.264/H.265 decode via NDL DirectMedia API
-  * Configurable resolution (1080p/1440p/4K), frame rate, bitrate, HDR, and audio channels
-  * Game library browsing with cover art and direct launch
-  * Network speed test with one-press recommended bitrate
-  * Wake-on-LAN for offline hosts
-  * Magic Remote friendly: d-pad, pointer, number-pad entry
+  Needs a [punktfunk](https://git.unom.io/unom/punktfunk) host running on your PC — see the
+  [host setup guide](https://git.unom.io/unom/punktfunk#readme) to get started.
 
-  ## Screenshots
-
-  ![Home](https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/screenshots/home.jpg)
-  ![Settings](https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/screenshots/settings.jpg)
+  webOS client by [dyptan-io](https://github.com/dyptan-io).
+  punktfunk is created by Enrico Bühler ([unom](https://unom.io)).
+  MIT / Apache-2.0.
 
 funding:
   github: [dyptan-io]

--- a/packages/io.dyptan.punktfunk.webos.yml
+++ b/packages/io.dyptan.punktfunk.webos.yml
@@ -25,3 +25,6 @@ description: |
 
 funding:
   github: [dyptan-io]
+
+requirements:
+  webosRelease: '>=5'

--- a/packages/io.dyptan.punktfunk.webos.yml
+++ b/packages/io.dyptan.punktfunk.webos.yml
@@ -1,0 +1,29 @@
+title: punktfunk
+iconUri: https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/logo/logo-sidebar.png
+manifestUrl: https://github.com/dyptan-io/punktfunk-webos/releases/latest/download/io.dyptan.punktfunk.webos.manifest.json
+category: game
+pool: main
+description: |
+  Native LG webOS TV client for [punktfunk](https://git.unom.io/unom/punktfunk) — low-latency desktop & game streaming.
+
+  Targets webOS 5.x+ (developed and verified on an LG CX, webOS 5.6). Built on the punktfunk project
+  by Enrico Bühler — this is the webOS-specific client with SDL2 UI, NDL DirectMedia hardware video
+  decode, and webOS packaging.
+
+  ## Features
+
+  * LAN discovery (mDNS) or manual host addition by IP; PIN pairing with persisted trust
+  * Hardware H.264/H.265 decode via NDL DirectMedia API
+  * Configurable resolution (1080p/1440p/4K), frame rate, bitrate, HDR, and audio channels
+  * Game library browsing with cover art and direct launch
+  * Network speed test with one-press recommended bitrate
+  * Wake-on-LAN for offline hosts
+  * Magic Remote friendly: d-pad, pointer, number-pad entry
+
+  ## Screenshots
+
+  ![Home](https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/screenshots/home.jpg)
+  ![Settings](https://raw.githubusercontent.com/dyptan-io/punktfunk-webos/main/assets/screenshots/settings.jpg)
+
+funding:
+  github: [dyptan-io]


### PR DESCRIPTION
#### Application description

Low-latency desktop & game streaming client for [punktfunk](https://git.unom.io/unom/punktfunk) hosts on LG webOS TVs.

- **App ID:** `io.dyptan.punktfunk.webos`
- **Source:** https://github.com/dyptan-io/punktfunk-webos
- **License:** MIT / Apache-2.0
- **Category:** game
- **Pool:** main (open source)
- **Latest release:** [v0.10.1](https://github.com/dyptan-io/punktfunk-webos/releases/tag/0.10.1)
- **Manifest:** https://github.com/dyptan-io/punktfunk-webos/releases/latest/download/io.dyptan.punktfunk.webos.manifest.json

Previously only installable via adding an external repository URL to Homebrew Channel. This PR makes it discoverable from the default app repo.

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [x] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [ ] Other (please describe below).