### PR TITLE
Add ScummVM package for LG webOS TVs

### DIFF
--- a/packages/org.scummvm.scummvm.yml
+++ b/packages/org.scummvm.scummvm.yml
@@ -1,0 +1,21 @@
+title: ScummVM
+iconUri: https://raw.githubusercontent.com/scummvm/scummvm/v2026.3.0/dists/emscripten/assets/scummvm-192.png
+manifestUrl: https://github.com/RF1705/scummvm-webos/releases/latest/download/org.scummvm.scummvm.manifest.json
+category: game
+pool: main
+description: |
+  ScummVM allows many classic graphical adventure games to run on modern
+  systems using their original game data files.
+
+  This package provides a native ARMv7 build of ScummVM for rooted LG webOS
+  TVs. It includes engines for many classic point-and-click adventures,
+  including Monkey Island, Full Throttle, The Dig, Myst, Riven, Blade Runner,
+  Broken Sword, Simon the Sorcerer and many others.
+
+  The application supports the LG Magic Remote and can use game data from
+  locations visible to the application, such as USB storage or network shares
+  exposed through a compatible network-storage application.
+
+  Game files are not included. Legally obtained original game data is required.
+
+  Root access and the Homebrew Channel are required.

--- a/packages/org.scummvm.scummvm.yml
+++ b/packages/org.scummvm.scummvm.yml
@@ -17,5 +17,3 @@ description: |
   exposed through a compatible network-storage application.
 
   Game files are not included. Legally obtained original game data is required.
-
-  Root access and the Homebrew Channel are required.


### PR DESCRIPTION
This package provides a native ARMv7 build of ScummVM for LG webOS TVs, allowing classic adventure games to run on modern systems.

#### Application description

ScummVM is a compatibility layer for running many classic graphical adventure games using their original game data files.

This package provides a native ARMv7 build for LG webOS TVs. It is intended for users who want to play supported adventure games directly on their television using the LG Magic Remote or another supported input device.

The build includes engines for games such as Monkey Island, Full Throttle, The Dig, Myst, Riven, Blade Runner, Broken Sword, Simon the Sorcerer, and many others.

Game data is not included. Users must provide legally obtained original game files. The application can access game data stored in locations visible to the application, including supported USB storage or network shares exposed inside the application jail.

The application has been tested on a real LG OLED65B19LA running webOS 6.5.3.

#### Submission checklist

* [x] I have tested this application on a real webOS TV.
* [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

* [ ] No AI tools were used.
* [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
* [ ] AI tools were used for research or planning; the application was developed by a human.
* [x] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
* [ ] The application was produced primarily by AI without meaningful human development or review.
* [ ] Other (please describe below).

AI coding agents were used to assist with parts of the webOS packaging, build automation, and troubleshooting. The resulting code and generated package were reviewed by the submitter and tested on real webOS hardware.
