### PR TITLE
CI: tell package problems apart from tooling failures

### DIFF
--- a/.github/workflows/package-lint.yml
+++ b/.github/workflows/package-lint.yml
@@ -44,8 +44,30 @@ jobs:
 
       - name: Lint package information
         shell: bash
+        env:
+          # Lets the licence check use the API's authenticated rate limit instead of
+          # the 60/hour shared between everything on the runner's IP.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           export lint_retcode=0
+
+          # Exit code 1 means the submission needs fixing, so fail the check. Anything
+          # else means our own tooling could not run: annotate it and leave the PR alone,
+          # a re-run will settle it. See repogen/common.py.
+          run_check() {
+            local what="$1"; shift
+            local code=0
+            "$@" >> /tmp/lint-report.md || code=$?
+            if [ "${code}" -eq 0 ]; then
+              return 0
+            elif [ "${code}" -eq 1 ]; then
+              export lint_retcode=1
+            else
+              echo "::warning::${what} could not complete (exit ${code})"
+            fi
+            return "${code}"
+          }
+
           for changed_file in ${{ inputs.packages }}; do
             echo "# Check Results for $(basename "${changed_file}"):" >> /tmp/lint-report.md
             echo >> /tmp/lint-report.md
@@ -53,15 +75,17 @@ jobs:
             echo '## Package Metadata' >> /tmp/lint-report.md
             echo >> /tmp/lint-report.md
 
-            python3 -m repogen.lintpkg -f "${changed_file}" >> /tmp/lint-report.md || export lint_retcode=1
+            run_check "lint of ${changed_file}" python3 -m repogen.lintpkg -f "${changed_file}" || true
             echo >> /tmp/lint-report.md
 
             ipkfile=/tmp/$(sha256sum "${changed_file}" | cut -d ' ' -f 1).ipk
-            python3 -m repogen.downloadipk -i "${changed_file}" -o "${ipkfile}" >> /tmp/lint-report.md || { export lint_retcode=1; continue; }
+            run_check "IPK download for ${changed_file}" \
+              python3 -m repogen.downloadipk -i "${changed_file}" -o "${ipkfile}" || continue
 
             echo '## Compatibility Check' >> /tmp/lint-report.md
 
-            python3 -m repogen.check_compat -i "${changed_file}" -p "${ipkfile}" >> /tmp/lint-report.md || export lint_retcode=1
+            run_check "compatibility check for ${changed_file}" \
+              python3 -m repogen.check_compat -i "${changed_file}" -p "${ipkfile}" || true
           done
           exit ${lint_retcode}
 

--- a/repogen/check_compat.py
+++ b/repogen/check_compat.py
@@ -1,23 +1,123 @@
+import re
 import subprocess
 from pathlib import Path
+from typing import Optional, List, Dict
 
 from repogen import pkg_info
+from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
 from repogen.pkg_info import PackageInfo
+
+# Cells of the markdown compatibility table, e.g. '| ES2015 support | :x: | :ok: |'.
+_TABLE_ROW = re.compile(r'^\|(.+)\|$')
+
+# webosbrew-ipk-verify exit codes. Only INCOMPATIBLE says anything about the package;
+# the rest mean the tool itself could not do its job.
+_VERIFY_OK = 0
+_VERIFY_INCOMPATIBLE = 1
+_VERIFY_BAD_ARGS = 2
+_VERIFY_BAD_INPUT = 3
+_VERIFY_NO_FW_DATA = 4
+_VERIFY_WRITE_FAILED = 5
+
+_VERIFY_REASONS = {
+    _VERIFY_BAD_ARGS: 'the tool rejected its command line',
+    _VERIFY_BAD_INPUT: 'the IPK is missing, unreadable, or not in the expected format',
+    _VERIFY_NO_FW_DATA: 'no firmware data is available',
+    _VERIFY_WRITE_FAILED: 'the tool could not write its output',
+}
+
+
+def _split_row(line: str) -> Optional[List[str]]:
+    match = _TABLE_ROW.match(line.strip())
+    if not match:
+        return None
+    return [cell.strip() for cell in match.group(1).split('|')]
+
+
+def earliest_supported_release(report: str) -> Optional[str]:
+    """Find the oldest webOS release every feature row marks as supported.
+
+    The compatibility report renders one column per tested release and one ':ok:'/':x:'
+    row per required feature. The oldest release no row marks ':x:' is the floor the
+    package should declare. Returns None if no table can be read or nothing passes.
+
+    A report holds one table per component (app, service, ...) and those tables do not
+    have to share columns, so results are keyed by release rather than column position.
+    """
+    order: List[str] = []
+    supported: Dict[str, bool] = {}
+    releases: List[str] = []
+    for line in report.splitlines():
+        cells = _split_row(line)
+        if not cells or set(''.join(cells)) <= set('-: '):
+            continue  # separator row, or nothing to read
+        if ':ok:' not in cells and ':x:' not in cells:
+            if not cells[0]:
+                # Header of a new table: empty corner cell, then the release versions.
+                releases = cells[1:]
+                for release in releases:
+                    if release not in supported:
+                        supported[release] = True
+                        order.append(release)
+            continue  # descriptive row, e.g. the web engine versions
+        for release, cell in zip(releases, cells[1:]):
+            if cell == ':x:':
+                supported[release] = False
+    return next((release for release in order if supported[release]), None)
 
 
 def check(info_file: Path, package_file: Path):
     info: PackageInfo = pkg_info.from_package_info_file(info_file)
+    declared_release = info.get('requirements', {}).get('webosRelease', None)
     compat_check_args = ['--format', 'markdown', '--details']
-    if 'requirements' in info:
-        if 'webosRelease' in info['requirements']:
-            compat_check_args.extend(['--fw-releases', info["requirements"]["webosRelease"]])
+    if declared_release:
+        compat_check_args.extend(['--fw-releases', declared_release])
     p = subprocess.run(args=['webosbrew-ipk-verify', *compat_check_args, str(package_file.absolute())],
                        shell=False, stdout=subprocess.PIPE, universal_newlines=True)
     for line in p.stdout.splitlines():
         if line.startswith('## Package'):
             continue
         print(line)
-    exit(p.returncode)
+    if p.returncode == _VERIFY_OK:
+        exit(EXIT_OK)
+
+    if p.returncode == _VERIFY_INCOMPATIBLE:
+        _print_release_tip(p.stdout, declared_release)
+        exit(EXIT_PACKAGE_PROBLEM)
+
+    if p.returncode == _VERIFY_NO_FW_DATA and declared_release:
+        # --fw-releases matched nothing. With a declared range that is the input we can
+        # attribute, so report it as the submitter's to fix rather than a broken runner.
+        print()
+        print(f' * :x: `webosRelease: \'{declared_release}\'` matches no known webOS release')
+        exit(EXIT_PACKAGE_PROBLEM)
+
+    reason = _VERIFY_REASONS.get(p.returncode, f'it exited with status {p.returncode}')
+    print()
+    print('> [!NOTE]')
+    print(f'> The compatibility check could not run — {reason}. This is not a problem with the submission.')
+    exit(EXIT_TOOL_PROBLEM)
+
+
+def _print_release_tip(report: str, declared_release: Optional[str]):
+    floor = earliest_supported_release(report)
+    print()
+    print('> [!TIP]')
+    if not floor:
+        print('> If the package is not meant to support the releases listed above, declare the oldest one '
+              'it does support as `requirements.webosRelease` in the package file.')
+        return
+    if declared_release:
+        print(f'> `webosRelease: \'{declared_release}\'` is declared, but the oldest tested release this '
+              f'package runs on is **{floor}**. Raise the requirement to match what it supports:')
+    else:
+        print(f'> The oldest tested release this package runs on is **{floor}**. If it is not meant to '
+              f'support anything older, declare that and this check will pass:')
+    print('>')
+    print('> ```yaml')
+    print('> requirements:')
+    print(f'>   webosRelease: \'>={".".join(floor.split(".")[:2])}\'')
+    print('> ```')
 
 
 if __name__ == '__main__':

--- a/repogen/common.py
+++ b/repogen/common.py
@@ -9,6 +9,12 @@ import requests
 
 ITEMS_PER_PAGE: int = 50
 
+# Exit codes shared by the check entry points (lintpkg, check_compat), so CI can tell
+# "the submitter must fix something" apart from "our tooling could not run".
+EXIT_OK: int = 0
+EXIT_PACKAGE_PROBLEM: int = 1
+EXIT_TOOL_PROBLEM: int = 2
+
 F = TypeVar("F", bound=Callable)
 
 

--- a/repogen/lintpkg.py
+++ b/repogen/lintpkg.py
@@ -1,6 +1,7 @@
+import os
 import sys
 from pathlib import Path
-from typing import Tuple, List
+from typing import Tuple, List, Optional
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 from xml.etree import ElementTree
@@ -10,7 +11,14 @@ from markdown import Markdown
 from markdown.treeprocessors import Treeprocessor
 
 from repogen import pkg_info, validators
+from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
 from repogen.pkg_info import PackageInfo
+
+
+_SOURCE_HELP = ('`pool: main` declares the app as open source, so its source must be publicly '
+                'available. Point `sourceUrl` at the source repository, or set `pool: non-free`.')
+_LICENSE_HELP = ('`pool: main` declares the app as open source, so its source repository should carry '
+                 'a licence. Add a LICENSE file, or set `pool: non-free`.')
 
 
 class PackageInfoLinter:
@@ -19,6 +27,78 @@ class PackageInfoLinter:
     def _assert(errors: [str], condition, message):
         if not condition:
             errors.append(message)
+
+    @staticmethod
+    def _github_repo(source_url: str) -> Optional[Tuple[str, str]]:
+        """Return (owner, repo) if source_url points at a GitHub repository."""
+        parsed = urlparse(source_url)
+        if parsed.hostname not in ('github.com', 'www.github.com'):
+            return None
+        parts = [p for p in parsed.path.split('/') if p]
+        if len(parts) < 2:
+            return None
+        return parts[0], parts[1].removesuffix('.git')
+
+    def _check_source_license(self, info: PackageInfo, errors: List[str], warnings: List[str]):
+        """Packages in the `main` pool claim to be open source. Hold them to it.
+
+        Publicly reachable source is a hard requirement of that claim, so a missing or
+        unreachable `sourceUrl` is an error. Whether the licence itself is present and
+        recognisable is advisory: vendored code, forks and custom terms all need a human
+        to judge, and several already-listed packages would fail an automated verdict.
+        """
+        if info['pool'] != 'main':
+            return
+        source_url = info['manifest'].get('sourceUrl', None)
+        if not source_url:
+            errors.append(f'sourceUrl is missing from the manifest. {_SOURCE_HELP}')
+            return
+        repo = self._github_repo(source_url)
+        if not repo:
+            # Elsewhere only reachability can be checked; the licence needs a manual look.
+            self._check_url_reachable(source_url, errors, warnings)
+            warnings.append(f'Could not check the licence of {source_url} automatically. {_LICENSE_HELP}')
+            return
+        owner, name = repo
+        headers = {'Accept': 'application/vnd.github+json'}
+        # Unauthenticated GitHub API allows 60 requests/hour per IP, which shared CI
+        # runners burn through quickly. Use the workflow token when one is available.
+        token = os.environ.get('GITHUB_TOKEN', None)
+        if token:
+            headers['Authorization'] = f'Bearer {token}'
+        try:
+            resp = requests.get(f'https://api.github.com/repos/{owner}/{name}', headers=headers, timeout=30)
+        except requests.exceptions.RequestException as e:
+            warnings.append(f'Could not check the licence of {source_url}: {e}')
+            return
+        if resp.status_code == 404:
+            errors.append(f'sourceUrl {source_url} is not a publicly accessible repository. {_SOURCE_HELP}')
+            return
+        if resp.status_code != 200:
+            warnings.append(f'Could not check the licence of {source_url}: HTTP {resp.status_code}')
+            return
+        spdx = ((resp.json().get('license', None) or {}).get('spdx_id', None))
+        if not spdx:
+            warnings.append(f'No licence found in {source_url}. {_LICENSE_HELP}')
+        elif spdx == 'NOASSERTION':
+            # A licence file exists but GitHub could not identify it — custom or modified
+            # terms are still a licence, so this only warrants a look, not a rejection.
+            warnings.append(f'Licence of {source_url} could not be identified, please review it manually')
+
+    @staticmethod
+    def _check_url_reachable(source_url: str, errors: List[str], warnings: List[str]):
+        """Confirm a non-GitHub sourceUrl is publicly readable."""
+        try:
+            resp = requests.get(source_url, timeout=30)
+        except requests.exceptions.RequestException as e:
+            # Can't distinguish "gone" from "having a bad minute" — don't fail the PR.
+            warnings.append(f'Could not reach sourceUrl {source_url}: {e}')
+            return
+        if 400 <= resp.status_code < 500:
+            errors.append(f'sourceUrl {source_url} is not publicly accessible '
+                          f'(HTTP {resp.status_code}). {_SOURCE_HELP}')
+        elif resp.status_code >= 500:
+            warnings.append(f'Could not reach sourceUrl {source_url}: HTTP {resp.status_code}')
 
     class ImageProcessor(Treeprocessor):
 
@@ -62,6 +142,8 @@ class PackageInfoLinter:
             if not source_url or not source_url.startswith('https://github.com/webosbrew/'):
                 warnings.append('Only package from github.com/webosbrew can have id starting with `org.webosbrew.`')
 
+        self._check_source_license(info, errors, warnings)
+
         description = info.get('description', '')
         mk = Markdown()
         # patch in the customized image pattern matcher with url checking
@@ -99,13 +181,24 @@ if __name__ == '__main__':
         # Report every schema violation at once, not just the first.
         for msg in e.errors:
             print(' * :x: %s' % msg)
-        exit(1)
+        exit(EXIT_PACKAGE_PROBLEM)
+    except ValueError as e:
+        # Bad filename/extension, unparseable YAML — report it in the PR comment
+        # instead of dying with an empty report section.
+        print(' * :x: %s' % e)
+        exit(EXIT_PACKAGE_PROBLEM)
+    except requests.exceptions.HTTPError as e:
+        # The server answered, and said no: a deleted release or a wrong URL is the
+        # submitter's to fix.
+        print(' * :x: %s' % e)
+        exit(EXIT_PACKAGE_PROBLEM)
     except requests.exceptions.RequestException as e:
+        # Timeout, DNS, connection reset — nothing the submitter can act on.
         print(f'Could not download package info: {e}', file=sys.stderr)
-        exit(5)
+        exit(EXIT_TOOL_PROBLEM)
     except IOError as e:
         print(f'Could not open package info file: {e.strerror}', file=sys.stderr)
-        exit(3)
+        exit(EXIT_TOOL_PROBLEM)
 
     linter = PackageInfoLinter()
     lint_errors, lint_warnings = linter.lint(lint_pkginfo)
@@ -117,4 +210,4 @@ if __name__ == '__main__':
 
     if not len(lint_errors) and not len(lint_warnings):
         print(':white_check_mark: Check passed.')
-    exit(1 if len(lint_errors) else 0)
+    exit(EXIT_PACKAGE_PROBLEM if len(lint_errors) else EXIT_OK)

--- a/repogen/pkg_info.py
+++ b/repogen/pkg_info.py
@@ -79,7 +79,8 @@ def load_registry(info_path: Path, offline: bool = False) -> tuple[str, PackageR
     elif extension == '.py':
         pkgid, content = load_py_package(info_path, offline)
     else:
-        raise ValueError(f'Unrecognized info format {extension}')
+        raise ValueError(f'Unsupported package file `{info_path.name}` — package files must be '
+                         f'named `<package id>.yml`')
     validator = validators.for_schema('packages/PackageInfo.json')
     validators.validate(validator, content)
     return pkgid, content


### PR DESCRIPTION
Splits CI failures that are the submitter's to fix from failures that are ours, so a network blip or a missing firmware dataset stops reading like a broken submission.

## What changes

`package-lint` failed a PR on any non-zero exit. The check entry points now share a convention in `repogen/common.py`:

| Code | Meaning | Workflow |
|---|---|---|
| 0 | fine | pass |
| 1 | the submitter has something to fix | fail the check |
| 2 | our tooling could not run | `::warning::`, PR unaffected |

`check_compat` maps `webosbrew-ipk-verify`'s documented codes onto that instead of passing them through — only its code 1 means the package is incompatible. On incompatibility it now names the release floor:

> **TIP** — The oldest tested release this package runs on is **5.3.1**. If it is not meant to support anything older, declare that and this check will pass:
> ```yaml
> requirements:
>   webosRelease: '>=5.3'
> ```

A `webosRelease` matching no known release stays the submitter's problem; an unreadable IPK does not.

`lintpkg` gains a licence check for `pool: main`. Since `main` claims the app is open source, a missing or unreachable `sourceUrl` is an **error**; whether the licence is present and recognisable is only a **warning** — forks, vendored code and custom terms need a human to judge.

Two smaller fixes: an unusable package filename is reported instead of producing an empty report section, and an HTTP error fetching the manifest counts as a package problem rather than a transient one.

## Impact on existing packages

All 44 listed packages have a reachable `sourceUrl`, so nothing newly fails. Nine would show the licence advisory when next touched, including `org.webosbrew.hyperhdr.loader`, `org.webosbrew.hyperion.ng.loader` and `org.webosbrew.safeupdate`, which genuinely have no LICENSE file.

## Testing

Verified locally against toolbox 0.5.0-1 (`v20260802-8aad4f1`): its exit codes match the documentation, and all five `check_compat` paths behave (undeclared floor, declared-but-too-low, declared-correct, impossible range, corrupt IPK). `run_check`'s dispatch was checked per code in isolation.

An earlier revision of this branch carried a throwaway commit touching `packages/com.biliwebos.app.yml` so the package checks would run on a real runner. That passed, and the licence advisory rendered as intended in the PR comment without blocking the check. The commit has since been dropped.

Not covered by any real run: nothing here triggered exit 2, so the `::warning::`-without-failing branch is verified locally only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsCLEGz8zcQfASkAgvKbCG
