### PR TITLE
Add IPTV-for-webOS.

### DIFF
--- a/packages/com.odyssey.webos.iptv.yml
+++ b/packages/com.odyssey.webos.iptv.yml
@@ -1,0 +1,29 @@
+title: IPTV for webOS
+iconUri: https://raw.githubusercontent.com/ladepensy/IPTV-for-webOS/main/largeIcon.png
+manifestUrl: https://github.com/ladepensy/IPTV-for-webOS/releases/latest/download/com.odyssey.webos.iptv.manifest.json
+category: multimedia
+pool: main
+requirements:
+  webosRelease: '>=5.0'
+description: |
+  # IPTV for webOS
+
+  A lightweight IPTV player for LG webOS TVs. Users provide their own M3U
+  playlists and XMLTV programme sources; the application does not bundle
+  channels, playlists, or copyrighted media.
+
+  ## Legal use
+
+  Only use sources that you own or are legally authorized to access. The app
+  does not bypass DRM or provide unauthorized broadcasts.
+
+  ## Privacy
+
+  Playlist, programme, image, and media requests are sent to the endpoints
+  configured by the user. Source settings may be stored in local TV app
+  storage so the app can remember them. The project does not intentionally
+  include advertising or analytics services.
+
+  ## Source code
+
+  [GitHub](https://github.com/ladepensy/IPTV-for-webOS) — MIT License

--- a/packages/com.odyssey.webos.iptv.yml
+++ b/packages/com.odyssey.webos.iptv.yml
@@ -27,3 +27,6 @@ description: |
   ## Source code
 
   [GitHub](https://github.com/ladepensy/IPTV-for-webOS) — MIT License
+
+funding:
+  github: [ladepensy]

--- a/packages/com.odyssey.webos.iptv.yml
+++ b/packages/com.odyssey.webos.iptv.yml
@@ -1,5 +1,5 @@
 title: IPTV for webOS
-iconUri: https://raw.githubusercontent.com/ladepensy/IPTV-for-webOS/main/largeIcon.png
+iconUri: https://media.githubusercontent.com/media/ladepensy/IPTV-for-webOS/refs/heads/main/largeIcon.png
 manifestUrl: https://github.com/ladepensy/IPTV-for-webOS/releases/latest/download/com.odyssey.webos.iptv.manifest.json
 category: multimedia
 pool: main


### PR DESCRIPTION
#### Application description

IPTV for webOS is a lightweight IPTV player for LG webOS TVs.

The application allows users to add and manage their own M3U playlist sources, browse channels by source and group, view optional XMLTV programme information, and play authorized live streams through the TV's native media capabilities.

The application does not bundle channels, playlists, programme data, or media streams. Users must provide sources they own or are legally authorized to access. The application does not bypass DRM or provide unauthorized broadcasts.

Playlist, programme, image, and media requests are sent only to endpoints configured by the user. Source settings may be stored in the TV's local application storage so the app can remember them. The application does not intentionally include advertising or analytics services.

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [x] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [ ] Other (please describe below).

AI tools assisted with interaction design review, documentation, release configuration, and limited code changes. The application was developed and reviewed by the maintainer, and the automated test suite and production build pass successfully. Real-TV testing remains to be completed.
