### PR TITLE
Add Navidrome Stage (com.cheerchen.navidromestage)

### DIFF
--- a/packages/com.cheerchen.navidromestage.yml
+++ b/packages/com.cheerchen.navidromestage.yml
@@ -1,0 +1,18 @@
+title: Navidrome Stage
+iconUri: https://raw.githubusercontent.com/CheerChen/navidrome-stage-webos/main/assets/icons/icon-large.png
+manifestUrl: https://github.com/CheerChen/navidrome-stage-webos/releases/latest/download/com.cheerchen.navidromestage.manifest.json
+category: multimedia
+pool: main
+# ES2020 (optional chaining, nullish coalescing); Chromium 87+ / webOS 7.0+
+requirements:
+  webosRelease: '>=7.0'
+description: |
+  Full-screen lyric visualizer for LG webOS TVs, backed by a self-hosted
+  [Navidrome](https://github.com/navidrome/navidrome) (or Subsonic-compatible) server.
+  Plays a random queue and hands timed lyrics to one of nine visualizer stages.
+
+  Features: nine lyric stages, word- and phrase-level synced lyric highlighting,
+  cover-art color palettes, audio-reactive backgrounds, full D-pad and media-key
+  control, and English/Chinese UI. No root required; a Navidrome server is required.
+
+  Source: https://github.com/CheerChen/navidrome-stage-webos (AGPL-3.0)


### PR DESCRIPTION
#### Application description

**Navidrome Stage** is a native LG webOS client and full-screen lyric visualizer for the self-hosted [Navidrome](https://github.com/navidrome/navidrome) music server (any Subsonic / OpenSubsonic-compatible server works).

- **App ID:** `com.cheerchen.navidromestage`
- **Source:** https://github.com/CheerChen/navidrome-stage-webos (AGPL-3.0)
- **Category / pool:** multimedia / main
- **rootRequired:** false

Users connect the app to **their own** Navidrome (or Subsonic-compatible) server with their own credentials. There are **no built-in media sources** — all music comes from the user's server. The app plays a random queue and hands timed lyrics to one of nine visualizer stages. Timed lyrics rely on the OpenSubsonic `getLyricsBySongId` extension, with plain-text fallback.

**Features (short):** nine lyric visualizer stages, word- and phrase-level synced lyric highlighting, cover-art color palettes, audio-reactive backgrounds, full D-pad and media-transport-key control, resume of the last stage, and English/Chinese UI.

**Release assets**

- Manifest: https://github.com/CheerChen/navidrome-stage-webos/releases/latest/download/com.cheerchen.navidromestage.manifest.json
- Releases (IPK + manifest per version): https://github.com/CheerChen/navidrome-stage-webos/releases

`manifestUrl` points at `releases/latest`, so Homebrew Channel installs the current release.

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [x] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [ ] Other (please describe below).

### Tested on

| | |
|---|---|
| Model | LG OLED42C2PCA |
| webOS | 10.3.1 (build 3001, Rockhopper / ponytail-papikonda) |
| Install path | Sideload / developer partition (`com.cheerchen.navidromestage`) |
| Server | Self-hosted Navidrome; connected over LAN and tested on the TV |

### Reviewer test plan

1. Download and install the IPK from the Release assets above (or via catalog after merge).
2. Point the app at a self-hosted Navidrome (or Subsonic-compatible) server and sign in with your own credentials.
3. Verify that a random queue plays and that lyrics appear; use number keys `1`-`9` to switch visualizer stages.
4. Verify D-pad navigation and media-transport keys (play/pause, 10s skip on FF/RW).
5. Confirm no root is required and no media sources ship inside the IPK.
