### PR TITLE
Reject reserved ids and IPKs that install as something else

### DIFF
--- a/.github/workflows/package-lint.yml
+++ b/.github/workflows/package-lint.yml
@@ -6,6 +6,11 @@ on:
       packages:
         type: string
         required: true
+      added-packages:
+        description: 'Subset of `packages` that this change adds rather than edits.'
+        type: string
+        required: false
+        default: ''
 
 # Disable all permissions
 permissions: {}
@@ -75,7 +80,14 @@ jobs:
             echo '## Package Metadata' >> /tmp/lint-report.md
             echo >> /tmp/lint-report.md
 
-            run_check "lint of ${changed_file}" python3 -m repogen.lintpkg -f "${changed_file}" || true
+            # Rules that would orphan existing installs run only for added packages.
+            new_flag=''
+            case " ${{ inputs.added-packages }} " in
+              *" ${changed_file} "*) new_flag='--new' ;;
+            esac
+
+            run_check "lint of ${changed_file}" \
+              python3 -m repogen.lintpkg -f "${changed_file}" ${new_flag} || true
             echo >> /tmp/lint-report.md
 
             ipkfile=/tmp/$(sha256sum "${changed_file}" | cut -d ' ' -f 1).ipk

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       need-package: ${{ steps.changed_files.outputs.packages }}
       packages-files: ${{ steps.changed_files.outputs.packages_files }}
+      added-packages-files: ${{ steps.changed_files.outputs.packages_added_files }}
       need-site: ${{ steps.changed_files.outputs.site }}
     steps:
       - name: Check changed files
@@ -25,6 +26,10 @@ jobs:
           filters: |
             packages:
               - added|modified: 'packages/**'
+            # Rules that would orphan existing installs apply only to packages being
+            # added, so the lint needs to tell the two apart.
+            packages_added:
+              - added: 'packages/**'
             site:
               - '**'
               - '!packages/**'
@@ -36,6 +41,7 @@ jobs:
     uses: ./.github/workflows/package-lint.yml
     with:
       packages: ${{ needs.filter-paths.outputs.packages-files }}
+      added-packages: ${{ needs.filter-paths.outputs.added-packages-files }}
 
   site-check:
     needs: filter-paths

--- a/repogen/downloadipk.py
+++ b/repogen/downloadipk.py
@@ -1,11 +1,38 @@
-from sys import stderr, exit
-from pathlib import Path
 import json.decoder
+import tarfile
+from pathlib import Path
+from sys import stderr, exit
 
 import requests.exceptions
-
-from repogen import pkg_info
+from ar.archive import ArchiveError
 from jsonschema.exceptions import ValidationError
+
+from repogen import ipk_file, pkg_info
+from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
+
+
+def verify_ipk_id(ipk_path: str, expected_id: str) -> str | None:
+    """Return an error message if the IPK does not install as `expected_id`.
+
+    The manifest is a separate file from the package it points at, so an id renamed
+    there does not follow into the IPK. When the two disagree the TV installs the id
+    baked into appinfo.json, which is what Homebrew Channel then matches against for
+    updates — an app listed under one id and installed under another never registers
+    as installed.
+    """
+    try:
+        _, appinfo = ipk_file.get_appinfo(ipk_path)
+    except (ArchiveError, KeyError, ValueError, tarfile.TarError, OSError) as e:
+        return f'Could not read appinfo.json from the IPK: {e}'
+    actual_id = appinfo.get('id', None)
+    if not actual_id:
+        return 'The IPK has no id in its appinfo.json'
+    if actual_id != expected_id:
+        return (f'The IPK installs as `{actual_id}`, but this package is `{expected_id}`. '
+                f'Rebuild the IPK with the id set in appinfo.json, so the listed app and the '
+                f'installed app are the same — otherwise updates will never be offered.')
+    return None
+
 
 if __name__ == '__main__':
     import argparse
@@ -19,38 +46,48 @@ if __name__ == '__main__':
         pkginfo = pkg_info.from_package_info_file(Path(args.info))
     except (requests.exceptions.JSONDecodeError, json.decoder.JSONDecodeError) as e:
         print(f'Could not parse manifest: {e}')
-        exit(2)
-    except requests.RequestException as e:
-        print(f'Could not download package info: {e}')
-        exit(5)
-    except IOError as e:
-        print(f'Could not open package info file: {e.strerror}')
-        exit(3)
+        exit(EXIT_PACKAGE_PROBLEM)
     except ValidationError as e:
         print(f'Could not parse package info: {e.message}')
-        exit(4)
+        exit(EXIT_PACKAGE_PROBLEM)
+    except requests.exceptions.HTTPError as e:
+        # The server answered and said no — a wrong URL or a deleted release.
+        print(f'Could not download package info: {e}')
+        exit(EXIT_PACKAGE_PROBLEM)
+    except requests.RequestException as e:
+        print(f'Could not download package info: {e}', file=stderr)
+        exit(EXIT_TOOL_PROBLEM)
+    except IOError as e:
+        print(f'Could not open package info file: {e.strerror}', file=stderr)
+        exit(EXIT_TOOL_PROBLEM)
 
     try:
         ipk_url = pkginfo['manifest']['ipkUrl']
     except KeyError as e:
         print(f'Invalid package info: missing key {e}')
-        exit(6)
+        exit(EXIT_PACKAGE_PROBLEM)
 
     try:
         with requests.get(ipk_url, allow_redirects=True) as resp:
             resp.raise_for_status()
             try:
                 with open(args.output, 'wb') as f:
-                    try:
-                        f.write(resp.content)
-                    except IOError as e:
-                        print(f'Could not write to output IPK file: {e.strerror}')
-                        exit(9)
-                    else:
-                        print(f'IPK file downloaded: {args.output}', file=stderr)
+                    f.write(resp.content)
             except IOError as e:
-                print(f'Could not open output IPK file: {e.strerror}')
-                exit(8)
-    except requests.exceptions.RequestException as e:
+                print(f'Could not write the IPK to {args.output}: {e.strerror}', file=stderr)
+                exit(EXIT_TOOL_PROBLEM)
+    except requests.exceptions.HTTPError as e:
         print(f'Could not download IPK: {e}')
-        exit(7)
+        exit(EXIT_PACKAGE_PROBLEM)
+    except requests.exceptions.RequestException as e:
+        print(f'Could not download IPK: {e}', file=stderr)
+        exit(EXIT_TOOL_PROBLEM)
+
+    print(f'IPK file downloaded: {args.output}', file=stderr)
+
+    id_error = verify_ipk_id(args.output, pkginfo['id'])
+    if id_error:
+        print(' * :x: %s' % id_error)
+        exit(EXIT_PACKAGE_PROBLEM)
+
+    exit(EXIT_OK)

--- a/repogen/lintpkg.py
+++ b/repogen/lintpkg.py
@@ -15,6 +15,7 @@ from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
 from repogen.pkg_info import PackageInfo
 
 
+_WEBOSBREW_PREFIX = 'org.webosbrew.'
 _SOURCE_HELP = ('`pool: main` declares the app as open source, so its source must be publicly '
                 'available. Point `sourceUrl` at the source repository, or set `pool: non-free`.')
 _LICENSE_HELP = ('`pool: main` declares the app as open source, so its source repository should carry '
@@ -100,6 +101,38 @@ class PackageInfoLinter:
         elif resp.status_code >= 500:
             warnings.append(f'Could not reach sourceUrl {source_url}: HTTP {resp.status_code}')
 
+    def _check_id_namespace(self, info: PackageInfo, new_package: bool,
+                            errors: List[str], warnings: List[str]):
+        """`org.webosbrew.*` is the project's own namespace.
+
+        An app carrying it looks official in the TV's launcher and in the Homebrew
+        Channel listing, so packages from outside github.com/webosbrew must not claim it.
+
+        Only enforced on newly added packages. Several listed apps predate the rule, and
+        an id is what Homebrew Channel matches an install against — renaming one orphans
+        every TV that already has it, which is a worse outcome than the squatted name.
+        """
+        if not info['id'].startswith(_WEBOSBREW_PREFIX):
+            return
+        source_url = info['manifest'].get('sourceUrl', None)
+        if source_url and source_url.startswith('https://github.com/webosbrew/'):
+            return
+        message = (f'`{info["id"]}` uses the `{_WEBOSBREW_PREFIX}` namespace, which is reserved for '
+                   f'packages from github.com/webosbrew.')
+        repo = self._github_repo(source_url) if source_url else None
+        if repo:
+            suggestion = f'com.github.{repo[0].lower()}.{info["id"][len(_WEBOSBREW_PREFIX):]}'
+            message += f' Rename it to something under your own namespace, e.g. `{suggestion}`.'
+        else:
+            message += ' Rename it to something under your own namespace, e.g. `com.github.<username>.<package>`.'
+        if not new_package:
+            warnings.append(message + ' It predates this rule, so it keeps the id it is '
+                                      'already installed under.')
+            return
+        message += (' The id must be changed in the app itself (appinfo.json) and its manifest, '
+                    'not just in this file.')
+        errors.append(message)
+
     class ImageProcessor(Treeprocessor):
 
         def __init__(self, errors: [str]):
@@ -113,7 +146,9 @@ class PackageInfoLinter:
                     self.errors.append("Use HTTPS URL for %s" % src)
             return None
 
-    def lint(self, info: PackageInfo) -> Tuple[List[str], List[str]]:
+    def lint(self, info: PackageInfo, new_package: bool = False) -> Tuple[List[str], List[str]]:
+        """Lint `info`. `new_package` marks a package being added by this change, which
+        some rules only apply to — see _check_id_namespace."""
         errors: List[str] = []
         warnings: List[str] = []
 
@@ -136,11 +171,7 @@ class PackageInfoLinter:
             errors.append('iconUrl must be data URI or use HTTPS')
 
         # Process manifest
-        manifest = info['manifest']
-        if info['id'].startswith('org.webosbrew.'):
-            source_url = manifest.get('sourceUrl', None)
-            if not source_url or not source_url.startswith('https://github.com/webosbrew/'):
-                warnings.append('Only package from github.com/webosbrew can have id starting with `org.webosbrew.`')
+        self._check_id_namespace(info, new_package, errors, warnings)
 
         self._check_source_license(info, errors, warnings)
 
@@ -173,6 +204,9 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-f', '--file', required=True)
+    parser.add_argument('-n', '--new', action='store_true',
+                        help='the package is being added, not edited — enables rules that '
+                             'would orphan existing installs if applied retroactively')
     args = parser.parse_args()
 
     try:
@@ -201,7 +235,7 @@ if __name__ == '__main__':
         exit(EXIT_TOOL_PROBLEM)
 
     linter = PackageInfoLinter()
-    lint_errors, lint_warnings = linter.lint(lint_pkginfo)
+    lint_errors, lint_warnings = linter.lint(lint_pkginfo, new_package=args.new)
 
     for err in lint_errors:
         print(' * :x: %s' % err)


### PR DESCRIPTION
Two ways a package could claim an identity that was not its own.

`org.webosbrew.*` is the project's namespace, and an app carrying it reads as
official in the launcher and in the Homebrew Channel listing. That was only a
warning, and warnings do not stop anything. It is now an error naming the
replacement, e.g. `com.github.<username>.<package>`.

It applies to added packages only. Six listed apps predate the rule, and an id
is what Homebrew Channel matches an install against — renaming one orphans
every TV that already has it, which is worse than the name itself. Those keep
their id and get a warning; new submissions have no such excuse. The lint
learns which is which from a paths-filter that lists added files separately.

The second is what let org.wireguard through: the lint compared the file name
to the manifest, and the manifest to nothing. Both said org.wireguard while the
IPK installed org.webosbrew.wireguard — the rename never reached the package.
downloadipk now reads appinfo.json out of what it just fetched and fails when
it disagrees, which is also the only check that sees the id a TV will use.

Also fixes exit codes downloadipk never had: since the workflow started failing
only on 1, a dead ipkUrl exited 7 and passed as a warning.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DsCLEGz8zcQfASkAgvKbCG