### PR TITLE
Add WireGuard VPN

### DIFF
--- a/packages/com.github.cfernande1470.wireguard.yml
+++ b/packages/com.github.cfernande1470.wireguard.yml
@@ -1,0 +1,38 @@
+title: WireGuard VPN
+iconUri: https://raw.githubusercontent.com/cfernande1470/webos-wireguard/main/app/com.github.cfernande1470.wireguard/icon.png
+manifestUrl: https://github.com/cfernande1470/webos-wireguard/releases/latest/download/com.github.cfernande1470.wireguard.manifest.json
+category: system
+pool: main
+requirements:
+  webosRelease: '>=5.0'
+description: |
+  WireGuard VPN client for rooted LG webOS TVs using Homebrew Channel.
+
+  The app runs WireGuard in userspace through `wireguard-go`, because LG webOS stock kernels usually do not include
+  the WireGuard kernel module.
+
+  Features:
+
+  - Bundled 32-bit ARMv7 `wg`, `wireguard-go`, and configuration upload server, compatible with supported 32-bit and
+    64-bit LG TVs
+  - English and Spanish TV interface
+  - PIN-protected `wg0.conf` upload from a phone or computer
+  - Start, stop, status, routes, configuration, and logs from the TV UI
+  - Optional start on boot
+  - Runtime uninstall support
+
+  Requirements:
+
+  - Rooted LG webOS TV running webOS 5.0 or later
+  - Homebrew Channel root service
+  - `/dev/net/tun` support
+
+  Notes:
+
+  - DNS handling is not currently implemented.
+  - IPv6 addresses and routes are currently ignored.
+  - This app is intended for trusted personal VPN configurations.
+
+  Source: https://github.com/cfernande1470/webos-wireguard (MIT)
+funding:
+  github: [cfernande1470]

--- a/packages/com.github.cfernande1470.wireguard.yml
+++ b/packages/com.github.cfernande1470.wireguard.yml
@@ -16,7 +16,8 @@ description: |
   - Bundled 32-bit ARMv7 `wg`, `wireguard-go`, and configuration upload server, compatible with supported 32-bit and
     64-bit LG TVs
   - English and Spanish TV interface
-  - PIN-protected `wg0.conf` upload from a phone or computer
+  - Time-limited `wg0.conf` upload using a random access code, failed-attempt lockout, and automatic shutdown after a
+    successful upload
   - Start, stop, status, routes, configuration, and logs from the TV UI
   - Optional start on boot
   - Runtime uninstall support


### PR DESCRIPTION
#### Application description

Re-adds WireGuard VPN after the revert in #223, with all follow-up issues from #181 addressed:

- Consistent ID `com.github.cfernande1470.wireguard` across the manifest, IPK metadata, application/service IDs, and installed paths
- All bundled binaries rebuilt for 32-bit ARMv7
- MIT license added
- v1.0.2 release published with reproducible build and verification scripts

Release: https://github.com/cfernande1470/webos-wireguard/releases/tag/v1.0.2

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [x] Other (please describe below).

An AI coding agent assisted with implementing the maintainer-requested fixes, build/release verification, and PR preparation. I reviewed the changes and tested the clean install, payload installation, native ARMv7 binaries, upload server, and tunnel startup on a real 64-bit ARM LG webOS TV.
