### PR TITLE
PR check: show app title, description and icon; fix two dead icons

### DIFF
--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -47,12 +47,11 @@ jobs:
             exit
           fi
 
+          # The report holds text the submitter controls, so it never goes through a
+          # step output. An expression pastes its value into the workflow before the
+          # YAML is parsed, and a crafted app description could add inputs of its own.
+          # The comment action reads the file instead.
           echo "issue-number=$(cat 'package-lint-results/issue-number.txt')" >> "${GITHUB_OUTPUT}"
-
-          delimiter="$(openssl rand -hex 16)"
-          echo "content<<${delimiter}" >> "${GITHUB_OUTPUT}"
-          cat 'package-lint-results/lint-report.md' >> "${GITHUB_OUTPUT}"
-          echo "${delimiter}" >> "${GITHUB_OUTPUT}"
 
       - id: find_comment
         name: Find package lint results comment
@@ -69,5 +68,5 @@ jobs:
         with:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ steps.extract_package_lint_results.outputs.issue-number }}
-          body: ${{ steps.extract_package_lint_results.outputs.content }}
+          body-path: artifacts/package-lint-results/lint-report.md
           edit-mode: replace

--- a/packages/org.litefin.app.yml
+++ b/packages/org.litefin.app.yml
@@ -1,5 +1,5 @@
 title: Litefin
-iconUri: https://raw.githubusercontent.com/MoazSalem/litefin/development/icon-130.png
+iconUri: https://raw.githubusercontent.com/MoazSalem/litefin/fc3b09787eb87a0379ffec2387f9b0b7c9e1cae1/assets/icon-130.png
 manifestUrl: https://github.com/MoazSalem/litefin/releases/latest/download/manifest.json
 category: multimedia
 pool: main

--- a/packages/twitch.adamffdev.v1.yml
+++ b/packages/twitch.adamffdev.v1.yml
@@ -1,5 +1,5 @@
 title: Twitch AdFree
-iconUri: https://raw.githubusercontent.com/adamff-dev/twitch-adfree-webos/main/assets/icon.jpg
+iconUri: https://raw.githubusercontent.com/adamff-dev/twitch-adfree-webos/d79e51eb1db9f078393d2963517fd49a3668ec8d/assets/largeIcon.png
 manifestUrl: https://github.com/adamff-dev/twitch-adfree-webos/releases/latest/download/twitch.adamffdev.v1.manifest.json
 category: internet
 pool: main

--- a/repogen/check_compat.py
+++ b/repogen/check_compat.py
@@ -3,12 +3,19 @@ import subprocess
 from pathlib import Path
 from typing import Optional, List, Dict
 
-from repogen import pkg_info
+from repogen import pkg_info, report
 from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
 from repogen.pkg_info import PackageInfo
 
 # Cells of the markdown compatibility table, e.g. '| ES2015 support | :x: | :ok: |'.
 _TABLE_ROW = re.compile(r'^\|(.+)\|$')
+
+# Shapes webosbrew-ipk-verify writes: headings, bullets, tables, and collapsible
+# sections. Everything else in its output is plain text.
+_HEADING = re.compile(r'^(#{1,6}) +(.*)$')
+_BULLET = re.compile(r'^([*+-] +)(.*)$')
+_SUMMARY = re.compile(r'^<summary>(.*)</summary>$')
+_DETAILS = ('<details>', '</details>')
 
 # webosbrew-ipk-verify exit codes. Only INCOMPATIBLE says anything about the package;
 # the rest mean the tool itself could not do its job.
@@ -25,6 +32,56 @@ _VERIFY_REASONS = {
     _VERIFY_NO_FW_DATA: 'no firmware data is available',
     _VERIFY_WRITE_FAILED: 'the tool could not write its output',
 }
+
+
+def sanitize(output: str) -> str:
+    """Rebuild the compatibility report from shapes this code recognises.
+
+    webosbrew-ipk-verify reads names out of the package and writes them into its
+    report: the app and service ids, the file names of the binaries, the symbols
+    they import, the URLs a web app loads. All of that belongs to the submitter, and
+    the report becomes a comment on this repository, so keep the structure the tool
+    produced and escape everything it carries.
+
+    A value holding a line break can still forge a line of its own, and a forged
+    line that looks like a heading stays a heading. It cannot carry content, which
+    is what matters, and telling the two apart from out here is not possible.
+    """
+    lines: List[str] = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            lines.append('')
+            continue
+        if stripped in _DETAILS:
+            lines.append(stripped)
+            continue
+        summary = _SUMMARY.match(stripped)
+        if summary:
+            lines.append(f'<summary>{report.as_markdown(summary.group(1))}</summary>')
+            continue
+        heading = _HEADING.match(stripped)
+        if heading:
+            lines.append(f'{heading.group(1)} {report.as_markdown(heading.group(2))}')
+            continue
+        row = _TABLE_ROW.match(stripped)
+        if row:
+            cells = row.group(1).split('|')
+            if set(''.join(cells)) <= set('-: '):
+                lines.append(stripped)  # separator row, nothing to escape
+            else:
+                lines.append('| %s |' % ' | '.join(report.as_markdown(c.strip()) for c in cells))
+            continue
+        bullet = _BULLET.match(stripped)
+        if bullet:
+            lines.append(f'{bullet.group(1)}{report.as_markdown(bullet.group(2))}')
+            continue
+        text = report.as_markdown(stripped)
+        if text[:1] in '#>=~`+-0123456789':
+            # Plain text, so nothing here may start a block of its own.
+            text = f'\\{text}'
+        lines.append(text)
+    return '\n'.join(lines)
 
 
 def _split_row(line: str) -> Optional[List[str]]:
@@ -74,15 +131,15 @@ def check(info_file: Path, package_file: Path):
         compat_check_args.extend(['--fw-releases', declared_release])
     p = subprocess.run(args=['webosbrew-ipk-verify', *compat_check_args, str(package_file.absolute())],
                        shell=False, stdout=subprocess.PIPE, universal_newlines=True)
-    for line in p.stdout.splitlines():
-        if line.startswith('## Package'):
-            continue
-        print(line)
+    # The package id is already the section this report sits in.
+    verify_report = sanitize('\n'.join(line for line in p.stdout.splitlines()
+                                       if not line.startswith('## Package')))
+    print(verify_report)
     if p.returncode == _VERIFY_OK:
         exit(EXIT_OK)
 
     if p.returncode == _VERIFY_INCOMPATIBLE:
-        _print_release_tip(p.stdout, declared_release)
+        _print_release_tip(verify_report, declared_release)
         exit(EXIT_PACKAGE_PROBLEM)
 
     if p.returncode == _VERIFY_NO_FW_DATA and declared_release:

--- a/repogen/downloadipk.py
+++ b/repogen/downloadipk.py
@@ -64,9 +64,6 @@ def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
         print(report.as_html(description, _DESCRIPTION_LIMIT))
     print('</td></tr></table>')
     print()
-    print('<sub>Icon comes from the package file. Title and description come from '
-          '<code>appinfo.json</code> in the IPK, which the package file cannot change.</sub>')
-    print()
 
 
 if __name__ == '__main__':

--- a/repogen/downloadipk.py
+++ b/repogen/downloadipk.py
@@ -1,6 +1,5 @@
 import html
 import json.decoder
-import re
 import tarfile
 from pathlib import Path
 from sys import stderr, exit
@@ -9,7 +8,7 @@ import requests.exceptions
 from ar.archive import ArchiveError
 from jsonschema.exceptions import ValidationError
 
-from repogen import ipk_file, pkg_info
+from repogen import ipk_file, pkg_info, report
 from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
 from repogen.ipk_file import AppInfo
 
@@ -21,11 +20,6 @@ _ICON_WIDTH = 28
 # short enough that a padded one cannot bury the rest of the comment.
 _TITLE_LIMIT = 80
 _DESCRIPTION_LIMIT = 600
-
-# Characters that let text read as something it is not: C0 and C1 controls, bidi
-# overrides and isolates, and zero-width marks. A line feed survives, nothing else.
-_INVISIBLE = re.compile('[\x00-\x09\x0b-\x1f\x7f-\x9f'
-                        '\\u200b-\\u200f\\u202a-\\u202e\\u2060-\\u2064\\u2066-\\u2069\\ufeff]')
 
 
 def verify_ipk_id(appinfo: AppInfo, expected_id: str) -> str | None:
@@ -47,23 +41,6 @@ def verify_ipk_id(appinfo: AppInfo, expected_id: str) -> str | None:
     return None
 
 
-def _text(value, limit: int) -> str:
-    """Turn app-supplied text into one line of inline HTML.
-
-    The IPK belongs to the submitter and the report becomes a comment on this
-    repository, so treat every field as hostile. Drop the characters that can make
-    text read as something else, escape the rest, and cap the length.
-
-    Every line feed becomes a `<br>`, which also keeps the surrounding raw HTML block
-    free of blank lines. That is what stops the renderer from reading app text as
-    markdown, so keep it that way.
-    """
-    text = _INVISIBLE.sub('', str(value)).strip()
-    if len(text) > limit:
-        text = text[:limit].rstrip() + ' … (truncated)'
-    return html.escape(text, quote=False).replace('\n', '<br>')
-
-
 def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
     """Print what the app says about itself, for a reviewer to read.
 
@@ -81,10 +58,10 @@ def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
     print('## App Info')
     print()
     print('<table><tr><td>')
-    print(f'<h3>{icon}{_text(appinfo.get("title", ""), _TITLE_LIMIT)}</h3>')
+    print(f'<h3>{icon}{report.as_html(appinfo.get("title", ""), _TITLE_LIMIT)}</h3>')
     description = appinfo.get('appDescription', '')
     if description:
-        print(_text(description, _DESCRIPTION_LIMIT))
+        print(report.as_html(description, _DESCRIPTION_LIMIT))
     print('</td></tr></table>')
     print()
     print('<sub>Icon comes from the package file. Title and description come from '

--- a/repogen/downloadipk.py
+++ b/repogen/downloadipk.py
@@ -12,9 +12,9 @@ from repogen import ipk_file, pkg_info
 from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
 from repogen.ipk_file import AppInfo
 
-# Icon preview in the report, in pixels. App icons are 130x130.
-_ICON_WIDTH = 80
-_ICON_CELL_WIDTH = 100
+# Width of the icon preview, in pixels. It sits on the title line, so keep it near
+# the line height. App icons are 130x130.
+_ICON_WIDTH = 28
 
 
 def verify_ipk_id(appinfo: AppInfo, expected_id: str) -> str | None:
@@ -49,25 +49,21 @@ def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
     the TV and Homebrew Channel show, and nothing in the package file overrides them,
     so a reviewer cannot see them without opening the package.
 
-    Written as raw HTML, not a markdown table: it puts the icon beside the title the
-    way a launcher does, and a markdown cell cannot hold a heading.
+    Written as raw HTML, not a markdown table: the icon belongs on the title line the
+    way a launcher shows it, and a markdown cell cannot hold a heading.
     """
-    detail = f'<h3>{_text(appinfo.get("title", ""))}</h3>'
-    description = appinfo.get('appDescription', '')
-    if description:
-        detail += f'\n{_text(description)}'
+    icon = ''
+    if icon_uri.startswith('https://'):
+        icon = f'<img src="{html.escape(icon_uri)}" width="{_ICON_WIDTH}" align="absmiddle" alt=""> '
+    # A data: URI never renders in a comment, so that case shows the title alone.
     print('## App Info')
     print()
-    print('<table><tr>')
-    if icon_uri.startswith('https://'):
-        print(f'<td width="{_ICON_CELL_WIDTH}" align="center">'
-              f'<img src="{html.escape(icon_uri)}" width="{_ICON_WIDTH}" alt="App icon"></td>')
-    else:
-        # A data: URI does not render in a comment, so point at the package file instead.
-        print(f'<td width="{_ICON_CELL_WIDTH}" align="center"><sub>Data URI,<br>see the '
-              f'package file</sub></td>')
-    print(f'<td>{detail}</td>')
-    print('</tr></table>')
+    print('<table><tr><td>')
+    print(f'<h3>{icon}{_text(appinfo.get("title", ""))}</h3>')
+    description = appinfo.get('appDescription', '')
+    if description:
+        print(_text(description))
+    print('</td></tr></table>')
     print()
     print('<sub>Icon comes from the package file. Title and description come from '
           '<code>appinfo.json</code> in the IPK, which the package file cannot change.</sub>')

--- a/repogen/downloadipk.py
+++ b/repogen/downloadipk.py
@@ -1,3 +1,4 @@
+import html
 import json.decoder
 import tarfile
 from pathlib import Path
@@ -9,9 +10,13 @@ from jsonschema.exceptions import ValidationError
 
 from repogen import ipk_file, pkg_info
 from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
+from repogen.ipk_file import AppInfo
+
+# Height of the icon preview in the report, in pixels. Icons are 130x130.
+_ICON_HEIGHT = 65
 
 
-def verify_ipk_id(ipk_path: str, expected_id: str) -> str | None:
+def verify_ipk_id(appinfo: AppInfo, expected_id: str) -> str | None:
     """Return an error message if the IPK does not install as `expected_id`.
 
     The manifest is a separate file from the package it points at, so an id renamed
@@ -20,10 +25,6 @@ def verify_ipk_id(ipk_path: str, expected_id: str) -> str | None:
     updates — an app listed under one id and installed under another never registers
     as installed.
     """
-    try:
-        _, appinfo = ipk_file.get_appinfo(ipk_path)
-    except (ArchiveError, KeyError, ValueError, tarfile.TarError, OSError) as e:
-        return f'Could not read appinfo.json from the IPK: {e}'
     actual_id = appinfo.get('id', None)
     if not actual_id:
         return 'The IPK has no id in its appinfo.json'
@@ -32,6 +33,38 @@ def verify_ipk_id(ipk_path: str, expected_id: str) -> str | None:
                 f'Rebuild the IPK with the id set in appinfo.json, so the listed app and the '
                 f'installed app are the same — otherwise updates will never be offered.')
     return None
+
+
+def _cell(text: str) -> str:
+    """Fit arbitrary text into one markdown table cell."""
+    escaped = html.escape(text.strip(), quote=False).replace('|', '\\|')
+    return escaped.replace('\r\n', '\n').replace('\n', '<br>')
+
+
+def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
+    """Print what the app says about itself, for a reviewer to read.
+
+    The title and the description come from appinfo.json in the IPK. Those are what
+    the TV and Homebrew Channel show, and nothing in the package file overrides them,
+    so a reviewer cannot see them without opening the package.
+    """
+    print('## App Info')
+    print()
+    print('| | |')
+    print('| --- | --- |')
+    if icon_uri.startswith('https://'):
+        print(f'| Icon | <img src="{html.escape(icon_uri)}" height="{_ICON_HEIGHT}" alt="App icon"> |')
+    else:
+        # A data: URI does not render in a comment, so point at the package file instead.
+        print('| Icon | Data URI, see the package file |')
+    print(f'| Title | {_cell(appinfo.get("title", ""))} |')
+    description = appinfo.get('appDescription', '')
+    if description:
+        print(f'| Description | {_cell(description)} |')
+    print()
+    print('Icon comes from the package file. Title and description come from `appinfo.json` '
+          'in the IPK, which the package file cannot change.')
+    print()
 
 
 if __name__ == '__main__':
@@ -85,7 +118,15 @@ if __name__ == '__main__':
 
     print(f'IPK file downloaded: {args.output}', file=stderr)
 
-    id_error = verify_ipk_id(args.output, pkginfo['id'])
+    try:
+        _, ipk_appinfo = ipk_file.get_appinfo(args.output)
+    except (ArchiveError, KeyError, ValueError, tarfile.TarError, OSError) as e:
+        print(' * :x: Could not read appinfo.json from the IPK: %s' % e)
+        exit(EXIT_PACKAGE_PROBLEM)
+
+    print_appinfo_table(ipk_appinfo, pkginfo['iconUri'])
+
+    id_error = verify_ipk_id(ipk_appinfo, pkginfo['id'])
     if id_error:
         print(' * :x: %s' % id_error)
         exit(EXIT_PACKAGE_PROBLEM)

--- a/repogen/downloadipk.py
+++ b/repogen/downloadipk.py
@@ -48,8 +48,10 @@ def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
     the TV and Homebrew Channel show, and nothing in the package file overrides them,
     so a reviewer cannot see them without opening the package.
 
-    Written as raw HTML, not a markdown table: the icon belongs on the title line the
-    way a launcher shows it, and a markdown cell cannot hold a heading.
+    Written as raw HTML: the icon belongs on the title line the way a launcher shows
+    it, and markdown has no heading that can hold one. Keeping it one unbroken HTML
+    block is also what stops the renderer from reading the app's text as markdown,
+    so do not put a blank line in the middle of it.
     """
     icon = ''
     if icon_uri.startswith('https://'):
@@ -57,12 +59,10 @@ def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
     # A data: URI never renders in a comment, so that case shows the title alone.
     print('## App Info')
     print()
-    print('<table><tr><td>')
     print(f'<h3>{icon}{report.as_html(appinfo.get("title", ""), _TITLE_LIMIT)}</h3>')
     description = appinfo.get('appDescription', '')
     if description:
-        print(report.as_html(description, _DESCRIPTION_LIMIT))
-    print('</td></tr></table>')
+        print(f'<p>{report.as_html(description, _DESCRIPTION_LIMIT)}</p>')
     print()
 
 

--- a/repogen/downloadipk.py
+++ b/repogen/downloadipk.py
@@ -12,8 +12,9 @@ from repogen import ipk_file, pkg_info
 from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
 from repogen.ipk_file import AppInfo
 
-# Height of the icon preview in the report, in pixels. Icons are 130x130.
-_ICON_HEIGHT = 65
+# Icon preview in the report, in pixels. App icons are 130x130.
+_ICON_WIDTH = 80
+_ICON_CELL_WIDTH = 100
 
 
 def verify_ipk_id(appinfo: AppInfo, expected_id: str) -> str | None:
@@ -35,9 +36,9 @@ def verify_ipk_id(appinfo: AppInfo, expected_id: str) -> str | None:
     return None
 
 
-def _cell(text: str) -> str:
-    """Fit arbitrary text into one markdown table cell."""
-    escaped = html.escape(text.strip(), quote=False).replace('|', '\\|')
+def _text(text: str) -> str:
+    """Turn app-supplied text into inline HTML, keeping its line breaks."""
+    escaped = html.escape(text.strip(), quote=False)
     return escaped.replace('\r\n', '\n').replace('\n', '<br>')
 
 
@@ -47,23 +48,29 @@ def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
     The title and the description come from appinfo.json in the IPK. Those are what
     the TV and Homebrew Channel show, and nothing in the package file overrides them,
     so a reviewer cannot see them without opening the package.
+
+    Written as raw HTML, not a markdown table: it puts the icon beside the title the
+    way a launcher does, and a markdown cell cannot hold a heading.
     """
-    print('## App Info')
-    print()
-    print('| | |')
-    print('| --- | --- |')
-    if icon_uri.startswith('https://'):
-        print(f'| Icon | <img src="{html.escape(icon_uri)}" height="{_ICON_HEIGHT}" alt="App icon"> |')
-    else:
-        # A data: URI does not render in a comment, so point at the package file instead.
-        print('| Icon | Data URI, see the package file |')
-    print(f'| Title | {_cell(appinfo.get("title", ""))} |')
+    detail = f'<h3>{_text(appinfo.get("title", ""))}</h3>'
     description = appinfo.get('appDescription', '')
     if description:
-        print(f'| Description | {_cell(description)} |')
+        detail += f'\n{_text(description)}'
+    print('## App Info')
     print()
-    print('Icon comes from the package file. Title and description come from `appinfo.json` '
-          'in the IPK, which the package file cannot change.')
+    print('<table><tr>')
+    if icon_uri.startswith('https://'):
+        print(f'<td width="{_ICON_CELL_WIDTH}" align="center">'
+              f'<img src="{html.escape(icon_uri)}" width="{_ICON_WIDTH}" alt="App icon"></td>')
+    else:
+        # A data: URI does not render in a comment, so point at the package file instead.
+        print(f'<td width="{_ICON_CELL_WIDTH}" align="center"><sub>Data URI,<br>see the '
+              f'package file</sub></td>')
+    print(f'<td>{detail}</td>')
+    print('</tr></table>')
+    print()
+    print('<sub>Icon comes from the package file. Title and description come from '
+          '<code>appinfo.json</code> in the IPK, which the package file cannot change.</sub>')
     print()
 
 

--- a/repogen/downloadipk.py
+++ b/repogen/downloadipk.py
@@ -1,5 +1,6 @@
 import html
 import json.decoder
+import re
 import tarfile
 from pathlib import Path
 from sys import stderr, exit
@@ -15,6 +16,16 @@ from repogen.ipk_file import AppInfo
 # Width of the icon preview, in pixels. It sits on the title line, so keep it near
 # the line height. App icons are 130x130.
 _ICON_WIDTH = 28
+
+# How much app-supplied text the report shows. Long enough for a real description,
+# short enough that a padded one cannot bury the rest of the comment.
+_TITLE_LIMIT = 80
+_DESCRIPTION_LIMIT = 600
+
+# Characters that let text read as something it is not: C0 and C1 controls, bidi
+# overrides and isolates, and zero-width marks. A line feed survives, nothing else.
+_INVISIBLE = re.compile('[\x00-\x09\x0b-\x1f\x7f-\x9f'
+                        '\\u200b-\\u200f\\u202a-\\u202e\\u2060-\\u2064\\u2066-\\u2069\\ufeff]')
 
 
 def verify_ipk_id(appinfo: AppInfo, expected_id: str) -> str | None:
@@ -36,10 +47,21 @@ def verify_ipk_id(appinfo: AppInfo, expected_id: str) -> str | None:
     return None
 
 
-def _text(text: str) -> str:
-    """Turn app-supplied text into inline HTML, keeping its line breaks."""
-    escaped = html.escape(text.strip(), quote=False)
-    return escaped.replace('\r\n', '\n').replace('\n', '<br>')
+def _text(value, limit: int) -> str:
+    """Turn app-supplied text into one line of inline HTML.
+
+    The IPK belongs to the submitter and the report becomes a comment on this
+    repository, so treat every field as hostile. Drop the characters that can make
+    text read as something else, escape the rest, and cap the length.
+
+    Every line feed becomes a `<br>`, which also keeps the surrounding raw HTML block
+    free of blank lines. That is what stops the renderer from reading app text as
+    markdown, so keep it that way.
+    """
+    text = _INVISIBLE.sub('', str(value)).strip()
+    if len(text) > limit:
+        text = text[:limit].rstrip() + ' … (truncated)'
+    return html.escape(text, quote=False).replace('\n', '<br>')
 
 
 def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
@@ -59,10 +81,10 @@ def print_appinfo_table(appinfo: AppInfo, icon_uri: str):
     print('## App Info')
     print()
     print('<table><tr><td>')
-    print(f'<h3>{icon}{_text(appinfo.get("title", ""))}</h3>')
+    print(f'<h3>{icon}{_text(appinfo.get("title", ""), _TITLE_LIMIT)}</h3>')
     description = appinfo.get('appDescription', '')
     if description:
-        print(_text(description))
+        print(_text(description, _DESCRIPTION_LIMIT))
     print('</td></tr></table>')
     print()
     print('<sub>Icon comes from the package file. Title and description come from '

--- a/repogen/ipk_file.py
+++ b/repogen/ipk_file.py
@@ -18,6 +18,7 @@ class AppInfo(TypedDict):
     version: str
     type: str
     appDescription: NotRequired[str]
+    icon: NotRequired[str]
 
 
 def get_appinfo(ipk_path: str) -> tuple[Control, AppInfo]:

--- a/repogen/lintpkg.py
+++ b/repogen/lintpkg.py
@@ -10,7 +10,7 @@ import requests
 from markdown import Markdown
 from markdown.treeprocessors import Treeprocessor
 
-from repogen import pkg_info, validators
+from repogen import pkg_info, report, validators
 from repogen.common import EXIT_OK, EXIT_PACKAGE_PROBLEM, EXIT_TOOL_PROBLEM
 from repogen.pkg_info import PackageInfo
 
@@ -23,22 +23,6 @@ _LICENSE_HELP = ('`pool: main` declares the app as open source, so its source re
 # A 130x130 icon does not need more than this. Anything larger is a mistake, or an
 # attempt to hand the site and the PR comment something other than an icon.
 _ICON_SIZE_LIMIT = 512 * 1024
-# How much of an untrusted value a message repeats back. Enough to recognise a URL,
-# not enough to fill a comment.
-_QUOTE_LIMIT = 200
-
-
-def _quote(value) -> str:
-    """Repeat an untrusted value back in a report message, as inline code.
-
-    Manifests belong to their submitter and the report becomes a comment on this
-    repository. A backtick or a line break would end the code span and let the value
-    add markup of its own, so neither survives.
-    """
-    text = str(value).replace('`', "'").replace('\r', ' ').replace('\n', ' ')
-    if len(text) > _QUOTE_LIMIT:
-        text = text[:_QUOTE_LIMIT] + '…'
-    return f'`{text}`'
 
 
 class PackageInfoLinter:
@@ -77,7 +61,8 @@ class PackageInfoLinter:
         if not repo:
             # Elsewhere only reachability can be checked; the licence needs a manual look.
             self._check_url_reachable(source_url, errors, warnings)
-            warnings.append(f'Could not check the licence of {_quote(source_url)} automatically. {_LICENSE_HELP}')
+            warnings.append(f'Could not check the licence of {report.as_code(source_url)} automatically. '
+                            f'{_LICENSE_HELP}')
             return
         owner, name = repo
         headers = {'Accept': 'application/vnd.github+json'}
@@ -89,21 +74,23 @@ class PackageInfoLinter:
         try:
             resp = requests.get(f'https://api.github.com/repos/{owner}/{name}', headers=headers, timeout=30)
         except requests.exceptions.RequestException as e:
-            warnings.append(f'Could not check the licence of {_quote(source_url)}: {_quote(e)}')
+            warnings.append(f'Could not check the licence of {report.as_code(source_url)}: {report.as_code(e)}')
             return
         if resp.status_code == 404:
-            errors.append(f'sourceUrl {_quote(source_url)} is not a publicly accessible repository. {_SOURCE_HELP}')
+            errors.append(f'sourceUrl {report.as_code(source_url)} is not a publicly accessible repository. '
+                          f'{_SOURCE_HELP}')
             return
         if resp.status_code != 200:
-            warnings.append(f'Could not check the licence of {_quote(source_url)}: HTTP {resp.status_code}')
+            warnings.append(f'Could not check the licence of {report.as_code(source_url)}: HTTP {resp.status_code}')
             return
         spdx = ((resp.json().get('license', None) or {}).get('spdx_id', None))
         if not spdx:
-            warnings.append(f'No licence found in {_quote(source_url)}. {_LICENSE_HELP}')
+            warnings.append(f'No licence found in {report.as_code(source_url)}. {_LICENSE_HELP}')
         elif spdx == 'NOASSERTION':
             # A licence file exists but GitHub could not identify it — custom or modified
             # terms are still a licence, so this only warrants a look, not a rejection.
-            warnings.append(f'Licence of {_quote(source_url)} could not be identified, please review it manually')
+            warnings.append(f'Licence of {report.as_code(source_url)} could not be identified, '
+                            f'please review it manually')
 
     @staticmethod
     def _check_icon(icon_uri: str, errors: List[str], warnings: List[str]):
@@ -126,7 +113,7 @@ class PackageInfoLinter:
                 return
             content_type = resp.headers.get('Content-Type', '').split(';')[0].strip()
             if not content_type.startswith('image/'):
-                errors.append(f'iconUri must serve an image, but it serves {_quote(content_type)}')
+                errors.append(f'iconUri must serve an image, but it serves {report.as_code(content_type)}')
             if len(resp.content) > _ICON_SIZE_LIMIT:
                 warnings.append(f'iconUri is {len(resp.content) // 1024} KiB. Icons show at 130x130, '
                                 f'so anything over {_ICON_SIZE_LIMIT // 1024} KiB is wasted download.')
@@ -138,13 +125,13 @@ class PackageInfoLinter:
             resp = requests.get(source_url, timeout=30)
         except requests.exceptions.RequestException as e:
             # Can't distinguish "gone" from "having a bad minute" — don't fail the PR.
-            warnings.append(f'Could not reach sourceUrl {_quote(source_url)}: {_quote(e)}')
+            warnings.append(f'Could not reach sourceUrl {report.as_code(source_url)}: {report.as_code(e)}')
             return
         if 400 <= resp.status_code < 500:
-            errors.append(f'sourceUrl {_quote(source_url)} is not publicly accessible '
+            errors.append(f'sourceUrl {report.as_code(source_url)} is not publicly accessible '
                           f'(HTTP {resp.status_code}). {_SOURCE_HELP}')
         elif resp.status_code >= 500:
-            warnings.append(f'Could not reach sourceUrl {_quote(source_url)}: HTTP {resp.status_code}')
+            warnings.append(f'Could not reach sourceUrl {report.as_code(source_url)}: HTTP {resp.status_code}')
 
     def _check_id_namespace(self, info: PackageInfo, new_package: bool,
                             errors: List[str], warnings: List[str]):
@@ -167,7 +154,7 @@ class PackageInfoLinter:
         repo = self._github_repo(source_url) if source_url else None
         if repo:
             suggestion = f'com.github.{repo[0].lower()}.{info["id"][len(_WEBOSBREW_PREFIX):]}'
-            message += f' Rename it to something under your own namespace, e.g. {_quote(suggestion)}.'
+            message += f' Rename it to something under your own namespace, e.g. {report.as_code(suggestion)}.'
         else:
             message += ' Rename it to something under your own namespace, e.g. `com.github.<username>.<package>`.'
         if not new_package:
@@ -188,7 +175,7 @@ class PackageInfoLinter:
             for img in root.findall('.//img'):
                 src = img.attrib['src']
                 if urlparse(src).scheme != 'https':
-                    self.errors.append('Use HTTPS URL for %s' % _quote(src))
+                    self.errors.append('Use HTTPS URL for %s' % report.as_code(src))
             return None
 
     def lint(self, info: PackageInfo, new_package: bool = False) -> Tuple[List[str], List[str]]:

--- a/repogen/lintpkg.py
+++ b/repogen/lintpkg.py
@@ -20,6 +20,25 @@ _SOURCE_HELP = ('`pool: main` declares the app as open source, so its source mus
                 'available. Point `sourceUrl` at the source repository, or set `pool: non-free`.')
 _LICENSE_HELP = ('`pool: main` declares the app as open source, so its source repository should carry '
                  'a licence. Add a LICENSE file, or set `pool: non-free`.')
+# A 130x130 icon does not need more than this. Anything larger is a mistake, or an
+# attempt to hand the site and the PR comment something other than an icon.
+_ICON_SIZE_LIMIT = 512 * 1024
+# How much of an untrusted value a message repeats back. Enough to recognise a URL,
+# not enough to fill a comment.
+_QUOTE_LIMIT = 200
+
+
+def _quote(value) -> str:
+    """Repeat an untrusted value back in a report message, as inline code.
+
+    Manifests belong to their submitter and the report becomes a comment on this
+    repository. A backtick or a line break would end the code span and let the value
+    add markup of its own, so neither survives.
+    """
+    text = str(value).replace('`', "'").replace('\r', ' ').replace('\n', ' ')
+    if len(text) > _QUOTE_LIMIT:
+        text = text[:_QUOTE_LIMIT] + '…'
+    return f'`{text}`'
 
 
 class PackageInfoLinter:
@@ -58,7 +77,7 @@ class PackageInfoLinter:
         if not repo:
             # Elsewhere only reachability can be checked; the licence needs a manual look.
             self._check_url_reachable(source_url, errors, warnings)
-            warnings.append(f'Could not check the licence of {source_url} automatically. {_LICENSE_HELP}')
+            warnings.append(f'Could not check the licence of {_quote(source_url)} automatically. {_LICENSE_HELP}')
             return
         owner, name = repo
         headers = {'Accept': 'application/vnd.github+json'}
@@ -70,21 +89,47 @@ class PackageInfoLinter:
         try:
             resp = requests.get(f'https://api.github.com/repos/{owner}/{name}', headers=headers, timeout=30)
         except requests.exceptions.RequestException as e:
-            warnings.append(f'Could not check the licence of {source_url}: {e}')
+            warnings.append(f'Could not check the licence of {_quote(source_url)}: {_quote(e)}')
             return
         if resp.status_code == 404:
-            errors.append(f'sourceUrl {source_url} is not a publicly accessible repository. {_SOURCE_HELP}')
+            errors.append(f'sourceUrl {_quote(source_url)} is not a publicly accessible repository. {_SOURCE_HELP}')
             return
         if resp.status_code != 200:
-            warnings.append(f'Could not check the licence of {source_url}: HTTP {resp.status_code}')
+            warnings.append(f'Could not check the licence of {_quote(source_url)}: HTTP {resp.status_code}')
             return
         spdx = ((resp.json().get('license', None) or {}).get('spdx_id', None))
         if not spdx:
-            warnings.append(f'No licence found in {source_url}. {_LICENSE_HELP}')
+            warnings.append(f'No licence found in {_quote(source_url)}. {_LICENSE_HELP}')
         elif spdx == 'NOASSERTION':
             # A licence file exists but GitHub could not identify it — custom or modified
             # terms are still a licence, so this only warrants a look, not a rejection.
-            warnings.append(f'Licence of {source_url} could not be identified, please review it manually')
+            warnings.append(f'Licence of {_quote(source_url)} could not be identified, please review it manually')
+
+    @staticmethod
+    def _check_icon(icon_uri: str, errors: List[str], warnings: List[str]):
+        """Confirm the icon is an image, and small enough to show.
+
+        The PR check renders this URL in a comment on this repository, so what it
+        serves has to be an image and nothing else. Size is only advisory: a heavy
+        icon is a waste, not a reason to reject a package.
+        """
+        scheme = urlparse(icon_uri).scheme
+        if scheme == 'data':
+            # Inline data, nothing to fetch. The schema already checks the syntax.
+            return
+        if scheme != 'https':
+            errors.append('iconUri must be a data URI or use HTTPS')
+            return
+        with requests.get(icon_uri, timeout=30) as resp:
+            if resp.status_code != 200:
+                errors.append(f'iconUri must be accessible (HTTP {resp.status_code})')
+                return
+            content_type = resp.headers.get('Content-Type', '').split(';')[0].strip()
+            if not content_type.startswith('image/'):
+                errors.append(f'iconUri must serve an image, but it serves {_quote(content_type)}')
+            if len(resp.content) > _ICON_SIZE_LIMIT:
+                warnings.append(f'iconUri is {len(resp.content) // 1024} KiB. Icons show at 130x130, '
+                                f'so anything over {_ICON_SIZE_LIMIT // 1024} KiB is wasted download.')
 
     @staticmethod
     def _check_url_reachable(source_url: str, errors: List[str], warnings: List[str]):
@@ -93,13 +138,13 @@ class PackageInfoLinter:
             resp = requests.get(source_url, timeout=30)
         except requests.exceptions.RequestException as e:
             # Can't distinguish "gone" from "having a bad minute" — don't fail the PR.
-            warnings.append(f'Could not reach sourceUrl {source_url}: {e}')
+            warnings.append(f'Could not reach sourceUrl {_quote(source_url)}: {_quote(e)}')
             return
         if 400 <= resp.status_code < 500:
-            errors.append(f'sourceUrl {source_url} is not publicly accessible '
+            errors.append(f'sourceUrl {_quote(source_url)} is not publicly accessible '
                           f'(HTTP {resp.status_code}). {_SOURCE_HELP}')
         elif resp.status_code >= 500:
-            warnings.append(f'Could not reach sourceUrl {source_url}: HTTP {resp.status_code}')
+            warnings.append(f'Could not reach sourceUrl {_quote(source_url)}: HTTP {resp.status_code}')
 
     def _check_id_namespace(self, info: PackageInfo, new_package: bool,
                             errors: List[str], warnings: List[str]):
@@ -122,7 +167,7 @@ class PackageInfoLinter:
         repo = self._github_repo(source_url) if source_url else None
         if repo:
             suggestion = f'com.github.{repo[0].lower()}.{info["id"][len(_WEBOSBREW_PREFIX):]}'
-            message += f' Rename it to something under your own namespace, e.g. `{suggestion}`.'
+            message += f' Rename it to something under your own namespace, e.g. {_quote(suggestion)}.'
         else:
             message += ' Rename it to something under your own namespace, e.g. `com.github.<username>.<package>`.'
         if not new_package:
@@ -143,7 +188,7 @@ class PackageInfoLinter:
             for img in root.findall('.//img'):
                 src = img.attrib['src']
                 if urlparse(src).scheme != 'https':
-                    self.errors.append("Use HTTPS URL for %s" % src)
+                    self.errors.append('Use HTTPS URL for %s' % _quote(src))
             return None
 
     def lint(self, info: PackageInfo, new_package: bool = False) -> Tuple[List[str], List[str]]:
@@ -160,15 +205,7 @@ class PackageInfoLinter:
             errors.append('id in manifest must match id in info')
 
         # Process icon
-        icon_uri = urlparse(info['iconUri'])
-        if icon_uri.scheme == 'data' or icon_uri.scheme == 'https':
-            with requests.get(info['iconUri']) as resp:
-                if resp.status_code == 200:
-                    pass
-                else:
-                    errors.append("iconUri must be accessible")
-        else:
-            errors.append('iconUrl must be data URI or use HTTPS')
+        self._check_icon(info['iconUri'], errors, warnings)
 
         # Process manifest
         self._check_id_namespace(info, new_package, errors, warnings)

--- a/repogen/report.py
+++ b/repogen/report.py
@@ -1,0 +1,64 @@
+"""Helpers for text that goes into the PR check report.
+
+The report becomes a comment on this repository, and most of what it shows comes
+from the package under review: the title and description in appinfo.json, the URLs
+in the manifest, the file and symbol names the compatibility check reads out of the
+IPK. All of it belongs to the submitter, so all of it passes through here first.
+
+The rule is the same in every form below. Text may say anything. It may not add
+content of its own: no raw HTML, no image, no link, no extra table column, and no
+character that makes it read as something it is not.
+"""
+import html
+import re
+
+# Characters that let text read as something it is not: C0 and C1 controls, bidi
+# overrides and isolates, and zero-width marks. A line feed survives, nothing else.
+_INVISIBLE = re.compile('[\x00-\x09\x0b-\x1f\x7f-\x9f'
+                        '\\u200b-\\u200f\\u202a-\\u202e\\u2060-\\u2064\\u2066-\\u2069\\ufeff]')
+
+# How much of a value a message repeats back. Enough to recognise a URL, not enough
+# to fill a comment.
+CODE_LIMIT = 200
+
+
+def plain(value, limit: int | None = None) -> str:
+    """Strip a value down to text, and cap it."""
+    text = _INVISIBLE.sub('', str(value)).strip()
+    if limit is not None and len(text) > limit:
+        text = text[:limit].rstrip() + ' … (truncated)'
+    return text
+
+
+def as_html(value, limit: int | None = None) -> str:
+    """Render a value inside a raw HTML block, keeping its line breaks.
+
+    Every line feed becomes a `<br>`, which also keeps the block free of blank
+    lines. That is what stops the renderer from reading the value as markdown, so
+    keep it that way.
+    """
+    return html.escape(plain(value, limit), quote=False).replace('\n', '<br>')
+
+
+def as_code(value, limit: int | None = CODE_LIMIT) -> str:
+    """Repeat a value back as inline code.
+
+    A backtick or a line break would end the code span and let the value carry on in
+    markup of its own, so neither survives.
+    """
+    text = plain(value, limit).replace('`', "'").replace('\n', ' ')
+    return f'`{text}`'
+
+
+def as_markdown(value, limit: int | None = None) -> str:
+    """Render a value as markdown text, in one line.
+
+    Escapes what can put content in the comment: raw HTML, a link or an image, and
+    a table column break. Emphasis and code spans are left alone. They can only
+    change how the text looks, and the compatibility report needs them.
+    """
+    text = plain(value, limit).replace('\n', ' ').replace('\\', '\\\\')
+    text = html.escape(text, quote=False)
+    for char in '[]|':
+        text = text.replace(char, f'\\{char}')
+    return text


### PR DESCRIPTION
## PR check report

The report never showed what the app says about itself. Title and description live
in `appinfo.json` inside the IPK, and the package file cannot change them, so a
reviewer had to download the package to see what the TV and Homebrew Channel show.
`repogen.downloadipk` now prints them with the listing icon.

Example, for `com.open.hidden.menu`:

## App Info

<h3><img src="https://raw.githubusercontent.com/nguy3nloan1986-dotcom/Open-Service-Menu/main/icon.png" width="28" align="absmiddle" alt=""> Open Service Menu</h3>
<p>An overlay app to quickly open webOS hidden service menus (inStart, ezAdjust, etc.) without interrupting the current app or HDMI input.<br><br>//!// Do not change anything in the hidden menu unless you know what you are doing //!//<br><br>App made by Kzu.<br>Thanks!</p>

Raw HTML, not markdown: the icon sits on the title line, and markdown has no heading
that can hold one. One unbroken HTML block also keeps the app's text out of the
markdown renderer. The description is dropped when the app has none, and GitHub
strips a `data:` image src, so a package with a data URI icon shows the title alone.

## Report hardening

Almost everything the report shows now belongs to the submitter, so all of it goes
through `repogen/report.py` first.

- App text is escaped, capped, and stripped of controls, bidi overrides and
  zero-width marks. Every line feed becomes a `<br>`, which keeps the HTML block
  free of blank lines and stops the renderer from reading app text as markdown.
- Lint messages quote manifest values as inline code, with backticks and line breaks
  removed, so a `sourceUrl` cannot add markup of its own.
- The compatibility report is rebuilt from the shapes `webosbrew-ipk-verify`
  produces, with everything they carry escaped. Its app ids, binary names, symbols
  and remote URLs all come out of the package.
- `iconUri` must serve an image. Over 512 KiB gets a warning.
- The comment action reads the report from a file. Passing it through a step output
  pasted submitter text into the workflow before YAML parsing, which a crafted app
  description could use to add inputs of its own.

## Dead icons

`org.litefin.app` and `twitch.adamffdev.v1` both had a 404 `iconUri`. The files
moved into `assets/`. Both links now point at the current path, pinned to the
commit that added it.

Twitch AdFree now uses `largeIcon.png` (130x130). The dead link was an 80x80 icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
