### PR TITLE
Add Magic Mapper

### DIFF
--- a/packages/com.github.afonsojramos.magicmapper.yml
+++ b/packages/com.github.afonsojramos.magicmapper.yml
@@ -4,6 +4,8 @@ manifestUrl: https://github.com/afonsojramos/magic-mapper-webos/releases/latest/
 category: utility
 pool: main
 shortDescription: Remap LG Magic Remote buttons from a TV-native interface
+requirements:
+  webosRelease: ">=7.4"
 description: |
   Magic Mapper provides a TV-native interface for discovering, disabling, and remapping buttons on
   an LG Magic Remote. It wraps the open-source

--- a/packages/com.github.afonsojramos.magicmapper.yml
+++ b/packages/com.github.afonsojramos.magicmapper.yml
@@ -1,0 +1,28 @@
+title: Magic Mapper
+iconUri: https://raw.githubusercontent.com/afonsojramos/magic-mapper-webos/main/largeIcon.png
+manifestUrl: https://github.com/afonsojramos/magic-mapper-webos/releases/latest/download/com.github.afonsojramos.magicmapper.manifest.json
+category: utility
+pool: main
+shortDescription: Remap LG Magic Remote buttons from a TV-native interface
+description: |
+  Magic Mapper provides a TV-native interface for discovering, disabling, and remapping buttons on
+  an LG Magic Remote. It wraps the open-source
+  [Magic Mapper](https://github.com/andrewfraley/magic_mapper) runtime so mappings can be managed
+  without editing JSON over SSH.
+
+  ![Remote button mappings](https://raw.githubusercontent.com/afonsojramos/magic-mapper-webos/main/assets/screenshots/remote-buttons.png)
+
+  ## Features
+
+  - Discover a remote button while suppressing its normal action.
+  - Disable branded shortcuts such as Netflix, Prime Video, Disney+, Rakuten TV, or Alexa.
+  - Launch an installed app or make one remote button behave like another.
+  - Adjust OLED light, energy saving, eye comfort, Dynamic Tone Mapping, and screen power.
+  - Send IR, HDMI-CEC, TCP, and webhook commands, or toggle PicCap.
+  - Restore individual buttons and remove the mapper cleanly from the TV.
+
+  ![Action catalogue](https://raw.githubusercontent.com/afonsojramos/magic-mapper-webos/main/assets/screenshots/action-catalog.png)
+
+  Root access, Homebrew Channel running as root, and Python 3 on the TV are required. The current
+  hardware target is an LG C3 running webOS 25; wider hardware compatibility has not yet been
+  claimed.


### PR DESCRIPTION
#### Application description

Adds Magic Mapper, a root-required, TV-native interface for discovering, disabling, and remapping
buttons on an LG Magic Remote. It wraps and pins the existing open-source Magic Mapper runtime and
exposes its complete action catalogue without requiring users to edit JSON over SSH.

The v1.1.1 release, public manifest, IPK hash, and package metadata have been validated locally. The
application and its Back-button, discovery, mapping, persistence, and uninstall flows were tested on
a real LG C3 running webOS 25.

This is separate from LG Input Hook: it is a managed UI and lifecycle wrapper around Magic Mapper,
including typed configuration for picture controls, installed apps, IR, HDMI-CEC, webhooks, TCP,
PicCap, and simulated remote buttons.

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [ ] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [x] Other (please describe below).

Codex was used extensively as a coding agent. The project owner directed the product and technical
decisions, iteratively tested the behavior on real hardware, reviewed each functional result, and
takes responsibility for the submitted code.

