### PR TITLE
chore: update decoder-bench requirements

### DIFF
--- a/packages/io.github.beatcracker.decoderbench.yml
+++ b/packages/io.github.beatcracker.decoderbench.yml
@@ -4,12 +4,12 @@ manifestUrl: https://github.com/beatcracker/decoder-bench/releases/latest/downlo
 category: multimedia
 pool: main
 requirements:
-  webosRelease: '>=5.0'
+  webosRelease: '>=4.0'
 description: |
   Native decoder benchmark for rooted LG webOS TVs.
 
-  Runs bundled or USB benchmark suites against the local video decoder pipeline and writes CSV/log results for codec, resolution, frame-rate, and bitrate limits. Built while chasing a Moonlight/Sunshine bitrate limit on an LG C1.
+  Runs bundled or USB benchmark suites against the local video decoder pipeline and writes CSV/log results for codec, resolution, frame-rate, and bitrate limits. Built while chasing a Moonlight/Sunshine bitrate limit on an LG C2.
 
   Requires root for USB access.
 
-  Download the full USB test suite from the [GitHub releases](https://github.com/beatcracker/decoder-bench/releases).
+  Download the full USB test suites (webOS 4.x and webOS 5+) from the [GitHub releases](https://github.com/beatcracker/decoder-bench/releases/latest).


### PR DESCRIPTION
#### Application description

Update [decoder-bench](https://github.com/webosbrew/apps-repo/pull/188) webOS compatibility requirements.
It runs on webOS 4.x now and has custom H.264-only test suite for these TVs.

Validated on real hardware: https://github.com/beatcracker/decoder-bench/issues/1

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [x] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [ ] Other (please describe below).

<!--
Applications made primarily by AI and submitted without meaningful human development, testing, and review are not
accepted. The submitter remains responsible for the application, including any AI-generated code.
-->
