### PR TITLE
Add HomeBack package listing

### DIFF
--- a/packages/com.homebrew.homeback.camera.yml
+++ b/packages/com.homebrew.homeback.camera.yml
@@ -1,0 +1,33 @@
+title: HomeBack Camera
+iconUri: https://raw.githubusercontent.com/angelcode1/webos-HomeBack/main/packages/pip-app/manifests/icon130.png
+manifestUrl: https://github.com/angelcode1/webos-HomeBack/releases/latest/download/com.homebrew.homeback.camera.manifest.json
+category: multimedia
+pool: main
+requirements:
+ webosRelease: '>=6.0'
+shortDescription: Native PiP camera companion for HomeBack Home Assistant integration
+description: |
+ # HomeBack Camera
+
+ HomeBack Camera is the optional native PiP companion for [HomeBack](https://github.com/angelcode1/webos-HomeBack). Install it alongside the main HomeBack package when you want Home Assistant camera notifications and manual camera viewing in LG's native Picture-in-Picture / Multi View interface.
+
+ ## What it does
+
+ - Receives the latest camera state from the HomeBack service
+ - Opens the selected camera in LG's native PiP / Multi View surface when you choose **Cameras** from the HomeBack ribbon
+ - Supports camera stream URLs with still-image fallback
+ - Uses a dedicated HomeBack-red camera icon so the companion is easy to identify
+ - Leaves PiP open until you exit using LG's Back/X controls
+
+ ## Requirements
+
+ - The matching **HomeBack** package must also be installed
+ - A rooted LG webOS TV with the webOS Homebrew Channel
+ - Home Assistant camera integration configured as described in the HomeBack README
+ - LG native Multi View / Picture-in-Picture support on the TV/firmware
+
+ This package is not intended to replace HomeBack or operate as a standalone camera application. It is the rendering companion used by HomeBack's Home Assistant camera workflow.
+
+ ## Source and license
+
+ Source code and documentation are maintained in the [HomeBack repository](https://github.com/angelcode1/webos-HomeBack). HomeBack Camera is distributed under GNU GPL v2.0 only (`GPL-2.0-only`).

--- a/packages/com.homebrew.homeback.yml
+++ b/packages/com.homebrew.homeback.yml
@@ -9,7 +9,7 @@ shortDescription: Fast replacement Home launcher with remote-button remapping
 description: |
  # HomeBack
 
- HomeBack is a fast replacement Home launcher for rooted LG TVs running webOS 6+. It gives you a compact app ribbon, a scrollable app drawer, quick access to Inputs and remote colour keys, a numeric keypad, and configurable short/long-press remote-button mappings.
+ HomeBack is a fast replacement Home launcher for rooted LG TVs running webOS 6+. It gives you a compact app ribbon, a scrollable app drawer, quick access to Inputs and remote colour keys, a numeric keypad, configurable short/long-press remote-button mappings, and optional Home Assistant camera integration.
 
  ## Features
 
@@ -20,12 +20,19 @@ description: |
  - **Keypad tile** — open the LG numeric on-screen keyboard and send 0–9 as TV remote key presses
  - **Red / Green / Yellow / Blue tiles** — send the matching LG colour key
  - **Custom remote mappings** — launch apps, replace keys, ignore keys, run short/long actions, or execute shell commands
+ - **Home Assistant cameras** — receive passive camera notifications and open the latest camera in LG native PiP from the HomeBack Cameras tile
 
  HomeBack includes its own remote-input service, so it should not be run alongside the standalone LG Input Hook app.
 
+ ## Optional Home Assistant camera support
+
+ Install the separate **HomeBack Camera** package (`com.homebrew.homeback.camera`) alongside HomeBack if you want the supported Home Assistant camera workflow. The companion is required to render camera stills/streams in LG's native Picture-in-Picture / Multi View surface when you select **Cameras** from the HomeBack ribbon.
+
+ The main HomeBack package works normally without the camera companion.
+
  ## Requirements
 
- A rooted LG webOS TV (webOS 6+) with the webOS Homebrew Channel installed. HomeBack uses Homebrew's root capabilities and boot hooks.
+ A rooted LG webOS TV (webOS 6+) with the webOS Homebrew Channel installed. HomeBack uses Homebrew's root capabilities and boot hooks. Camera PiP additionally requires LG native Multi View / Picture-in-Picture support on the TV/firmware.
 
  ## Credits and upstream projects
 

--- a/packages/com.homebrew.homeback.yml
+++ b/packages/com.homebrew.homeback.yml
@@ -1,9 +1,10 @@
-# CI retrigger: upstream IPK now includes Installed-Size (see webos-HomeBack release fix)
 title: HomeBack
 iconUri: https://raw.githubusercontent.com/angelcode1/webos-HomeBack/main/packages/app/manifests/icon130.png
 manifestUrl: https://github.com/angelcode1/webos-HomeBack/releases/latest/download/com.homebrew.homeback.manifest.json
 category: launcher
 pool: main
+requirements:
+ webosRelease: '>=6.0'
 shortDescription: Fast replacement Home launcher with remote-button remapping
 description: |
  # HomeBack

--- a/packages/com.homebrew.homeback.yml
+++ b/packages/com.homebrew.homeback.yml
@@ -1,0 +1,41 @@
+title: HomeBack
+iconUri: https://raw.githubusercontent.com/angelcode1/webos-HomeBack/main/packages/app/manifests/icon130.png
+manifestUrl: https://github.com/angelcode1/webos-HomeBack/releases/latest/download/com.homebrew.homeback.manifest.json
+category: launcher
+pool: main
+shortDescription: Fast replacement Home launcher with remote-button remapping
+description: |
+ # HomeBack
+
+ HomeBack is a fast replacement Home launcher for rooted LG TVs running webOS 6+. It gives you a compact app ribbon, a scrollable app drawer, quick access to Inputs and remote colour keys, a numeric keypad, and configurable short/long-press remote-button mappings.
+
+ ## Features
+
+ - **HOME tap** — show or hide the HomeBack ribbon
+ - **HOME hold** — open the stock LG Home screen
+ - **App drawer** — browse installed apps with the remote D-pad or Magic Remote wheel
+ - **Inputs tile** — open the LG input picker
+ - **Keypad tile** — open the LG numeric on-screen keyboard and send 0–9 as TV remote key presses
+ - **Red / Green / Yellow / Blue tiles** — send the matching LG colour key
+ - **Custom remote mappings** — launch apps, replace keys, ignore keys, run short/long actions, or execute shell commands
+
+ HomeBack includes its own remote-input service, so it should not be run alongside the standalone LG Input Hook app.
+
+ ## Requirements
+
+ A rooted LG webOS TV (webOS 6+) with the webOS Homebrew Channel installed. HomeBack uses Homebrew's root capabilities and boot hooks.
+
+ ## Credits and upstream projects
+
+ HomeBack stands on work from the webOS homebrew community:
+
+ - [AltHome by kitsuned](https://github.com/kitsuned/AltHome) — the replacement-launcher project HomeBack was originally derived from (GPL-2.0). HomeBack retains that GPL lineage.
+ - [LG Input Hook by Simon34545](https://github.com/Simon34545/lginputhook) — the original open-source LG remote-button remapper and native-hook lineage that inspired HomeBack's integrated remote interception (BSD-3-Clause).
+ - **smx-smx** — creator of `ezinject` / hookfactory.
+ - **Informatic** — creator of the original input-hook script.
+
+ HomeBack currently bundles `ezinject` and `libinputhookpp.so` from an unofficial community build commonly referred to as LG Input Hook 1.5.0, obtained from the webOS community after the public 1.4.0 project stopped working on newer TVs. The author of those binary modifications is not currently known, so HomeBack does not claim authorship of that bundled binary. See [THIRD_PARTY_NOTICES.md](https://github.com/angelcode1/webos-HomeBack/blob/main/THIRD_PARTY_NOTICES.md) for the full licensing breakdown.
+
+ ## License
+
+ HomeBack's source code is distributed under GNU GPL v2.0 only (`GPL-2.0-only`), consistent with the AltHome codebase from which it is derived. Third-party components and binaries keep their own rights and notices.

--- a/packages/com.homebrew.homeback.yml
+++ b/packages/com.homebrew.homeback.yml
@@ -1,3 +1,4 @@
+# CI retrigger: upstream IPK now includes Installed-Size (see webos-HomeBack release fix)
 title: HomeBack
 iconUri: https://raw.githubusercontent.com/angelcode1/webos-HomeBack/main/packages/app/manifests/icon130.png
 manifestUrl: https://github.com/angelcode1/webos-HomeBack/releases/latest/download/com.homebrew.homeback.manifest.json


### PR DESCRIPTION
<!--
This template is for application submissions. If this PR only changes repository infrastructure, tooling, or
documentation, please remove the template contents before submitting it.
-->

#### Application description

HomeBack is a fast replacement Home launcher for rooted LG webOS 6+ TVs. It adds a compact app ribbon/drawer, quick Inputs/keypad/colour-key tiles, and configurable remote-button remapping (short/long-press actions, key replacement, app launching, or shell commands) via its own integrated remote-input service, for owners of rooted LG webOS TVs who want a faster, more customizable Home experience.

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [ ] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [x] Other (please describe below).
Foundation models were used for iterative development, tested and working on LG C5 webOS 10.0 TV
<!--
Applications made primarily by AI and submitted without meaningful human development, testing, and review are not
accepted. The submitter remains responsible for the application, including any AI-generated code.
-->
