### PR TITLE
Add Pelagica

### DIFF
--- a/packages/app.pelagica.pelagica.yml
+++ b/packages/app.pelagica.pelagica.yml
@@ -4,6 +4,6 @@ manifestUrl: https://github.com/PelagicaApp/pelagica/releases/latest/download/ap
 category: multimedia
 pool: main
 requirements:
-  webosRelease: '>=5.0'
+  webosRelease: '>=7.4'
 description: |
   A fast, modern, and customizable Jellyfin client for webOS.

--- a/packages/app.pelagica.pelagica.yml
+++ b/packages/app.pelagica.pelagica.yml
@@ -1,0 +1,9 @@
+title: Pelagica
+iconUri: https://raw.githubusercontent.com/PelagicaApp/pelagica/refs/heads/main/.github/assets/logo/logo_webOS_160.png
+manifestUrl: https://github.com/PelagicaApp/pelagica/releases/latest/download/app.pelagica.pelagica.manifest.json
+category: multimedia
+pool: main
+requirements:
+  webosRelease: '>=5.0'
+description: |
+  A fast, modern, and customizable Jellyfin client for webOS.


### PR DESCRIPTION
#### Application description

Pelagica is an alternative [Jellyfin](https://jellyfin.org) client for webOS giving users a more modern and customizable interface made specifically for TV.

GitHub: https://github.com/PelagicaApp/pelagica
Website: https://pelagica.app/

#### Submission checklist

- [X] I have tested this application on a real webOS TV.
- [X] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [X] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [ ] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [ ] Other (please describe below).