### PR TITLE
Add IHSplay Pro (org.ihsplay.pro)

### DIFF
--- a/packages/org.ihsplay.pro.yml
+++ b/packages/org.ihsplay.pro.yml
@@ -1,0 +1,34 @@
+title: IHSplay Pro
+shortDescription: Improved IHSplay fork - Steam Remote Play for LG webOS
+iconUri: https://raw.githubusercontent.com/skwizzy222/ihsplay-pro/main/deploy/webos/largeIcon.png
+detailIconUri: https://raw.githubusercontent.com/skwizzy222/ihsplay-pro/main/deploy/webos/largeIcon.png
+manifestUrl: https://github.com/skwizzy222/ihsplay-pro/releases/latest/download/org.ihsplay.pro.manifest.json
+category: game
+pool: main
+description: |
+  # IHSplay Pro
+
+  An improved community fork of [IHSplay](https://github.com/mariotaku/ihsplay)
+  (GPL-3.0). Installs as a **separate** app (`org.ihsplay.pro`) and does **not**
+  replace upstream `org.mariotaku.ihsplay`.
+
+  ## Features
+
+  - Steam Remote Play client for LG webOS (Big Picture / Desktop)
+  - Add PC by IP, streaming PIN entry, cancel while connecting
+  - Bluetooth gamepad pairing/connect on the TV
+  - Selectable SS4S audio/video modules (with app restart)
+  - English UI by default; Russian available in Settings
+  - Support section with tips for reducing input lag
+
+  ## Notes
+
+  - Requires Steam on the PC with Remote Play enabled
+  - PC and TV should be on the same network (Ethernet on the PC preferred)
+  - Root is **not** required
+
+  ![Gamepad screen](https://raw.githubusercontent.com/skwizzy222/ihsplay-pro/main/deploy/webos/screenshot-gamepads.png)
+
+  Source: https://github.com/skwizzy222/ihsplay-pro
+funding:
+  github: [skwizzy222]


### PR DESCRIPTION
#### Application description

IHSplay Pro is an improved community fork of [IHSplay](https://github.com/mariotaku/ihsplay) (GPL-3.0) — an SDL2 Steam Remote Play / Steam Link-style client for LG webOS TVs.

It installs as a **separate** package (`org.ihsplay.pro`) and does **not** replace upstream `org.mariotaku.ihsplay`.

Features include discovering/adding a Steam PC (including by IP), streaming PIN entry, cancel while connecting, Bluetooth gamepad pairing/connect on the TV, selectable SS4S audio/video modules, English UI by default with optional Russian in Settings, and a Support section with lag tips.

The app streams content the user already owns/authorizes through Steam Remote Play on their own PC. It does not bypass DRM, pirate games, or ship third-party streams. No intentional advertising or analytics services are included.

- Source: https://github.com/skwizzy222/ihsplay-pro
- Manifest: https://github.com/skwizzy222/ihsplay-pro/releases/latest/download/org.ihsplay.pro.manifest.json
- Category: `game`, pool: `main`, `rootRequired: false`

#### Submission checklist

- [x] I have tested this application on a real webOS TV.
- [x] I confirm that this submission complies with the repository rules.

#### AI-use declaration

- [ ] No AI tools were used.
- [ ] AI tools were used for limited assistance (for example, explanations, small snippets, or editing).
- [ ] AI tools were used for research or planning; the application was developed by a human.
- [x] AI coding agents were used; an experienced developer has reviewed and tested all generated code.
- [ ] The application was produced primarily by AI without meaningful human development or review.
- [ ] Other (please describe below).

AI coding assistants (Cursor) helped with some UI/i18n/build tooling and store packaging. The submitter developed, reviewed, and tested the application on a real LG webOS TV (including Bluetooth gamepad pairing/connect, streaming UI, and settings). The submitter takes full responsibility for the code.